### PR TITLE
fix(fpm): Downgrade docker image to `debian:buster` for broader fpm support

### DIFF
--- a/.changeset/eager-frogs-post.md
+++ b/.changeset/eager-frogs-post.md
@@ -1,0 +1,5 @@
+---
+"fpm": patch
+---
+
+fix(fpm): downgrade docker image to debian:buster to support older distros

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x86_64, i386, arm64/v8] # , arm/v7, ppc64le, s390x]
+        arch: [amd64, i386, arm64/v8] # , arm/v7, ppc64le, s390x]
     steps:
       - name: Set up QEMU dependency
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392

--- a/packages/fpm/assets/Dockerfile
+++ b/packages/fpm/assets/Dockerfile
@@ -1,41 +1,38 @@
 # syntax=docker/dockerfile:1.4
 
 ARG TARGET_ARCH=x86_64
-ARG PLATFORM_ARCH=x86_64
+ARG PLATFORM_ARCH
 ARG RUBY_VERSION=3.4.3
-# ARG DOCKER_IMAGE=buildpack-deps:bookworm-curl
-ARG DOCKER_IMAGE=buildpack-deps:22.04-curl
 
-FROM --platform=linux/${PLATFORM_ARCH} ${DOCKER_IMAGE} AS build
+FROM --platform=linux/${PLATFORM_ARCH:-amd64} debian:buster
 
 ENV DEBIAN_FRONTEND=noninteractive
-
-# ---- Build stage ----
-# Install build dependencies
-RUN apt-get update -qq && apt-get install -yq \
-    gcc g++ make autoconf bison git \
-    libssl-dev libreadline-dev libyaml-dev \
-    zlib1g-dev libffi-dev libgdbm-dev \
-    file patchelf tar ruby-dev valgrind \
-    openssl libz-dev libyaml-dev p7zip-full xz-utils \
-    liblzma-dev
-
-# Enable 386 multilib toolchain if needed
-ARG TARGET_ARCH
-RUN if [ "$TARGET_ARCH" = "i386" ]; then \
-    dpkg --add-architecture i386 && \
-    apt-get update -qq && \
-    apt-get install -yq \
-    gcc-multilib g++-multilib valgrind:i386 libssl-dev:i386 \
-    libc6-dev:i386 libgcc-11-dev:i386 libstdc++-11-dev:i386 \
-    libz-dev:i386 libyaml-dev:i386 xz-utils:i386 \
-    liblzma-dev:i386; \
-    fi
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libssl-dev \
+    libreadline-dev \
+    zlib1g-dev \
+    libyaml-dev \
+    libffi-dev \
+    libgdbm-dev \
+    libncurses5-dev \
+    curl \
+    git \
+    autoconf \
+    bison \
+    pkg-config \
+    patchelf \
+    ruby-dev \
+    openssl \
+    p7zip-full \
+    xz-utils
 
 WORKDIR /tmp/assets
 
 ARG RUBY_VERSION
 ENV RUBY_VERSION=${RUBY_VERSION}
+
+ARG TARGET_ARCH
 ENV TARGET_ARCH=${TARGET_ARCH}
 
 COPY ./assets/constants.sh /tmp/assets/constants.sh

--- a/packages/fpm/assets/patch-portable-ruby.sh
+++ b/packages/fpm/assets/patch-portable-ruby.sh
@@ -193,53 +193,40 @@ if [ "$(uname)" = "Darwin" ]; then
 
     echo "✅ All dylib references made portable. Autocopied missing libraries where needed."
 else
-    echo "  🐧 Patching portable Ruby bundle for Linux."
+    WHITELISTED_LIBS=(
+        libssl.so
+        libcrypto.so
+        libreadline.so
+        libz.so
+        libyaml
+        liblzma.so
+        libffi.so
+        libgmp.so
+    )
 
     echo "  ⏩️ Copying shared libraries to $LIB_DIR"
-    SHARED_LIBRARIES=(
-        "libssl.so*"
-        "libcrypto.so*"
-        "libreadline.so*"
-        "libz.so*"
-        "libyaml-cpp.so*"
-        "liblzma.so*"
-    )
-    for pattern in "${SHARED_LIBRARIES[@]}"; do
-        find /usr/lib /lib -type f -name "$pattern" 2>/dev/null | while read -r filepath; do
-            dest="$LIB_DIR/$(basename $filepath)"
-            if [[ ! -f "$dest" ]]; then
-                echo "    📝 Copying $filepath"
-                cp -a "$filepath" "$dest"
-            fi
-        done
-    done
-
-    echo "  🔍 Scanning Ruby extensions for additional shared libraries..."
-    IFS=$'\n'
-    LDD_SEARCH_PATHS=("$RUBY_PREFIX/bin/ruby" $(find "$LIB_DIR/ruby" -type f -name '*.so'))
-    unset IFS
-
-    for ext_so in "${LDD_SEARCH_PATHS[@]}"; do
-        if [[ ! -f "$ext_so" ]]; then
-            echo "  ⏩️ Skipping $ext_so (not a file)"
-            continue
-        fi
-        SO_DIR=$(dirname "$ext_so")
-        REL_RPATH=$(realpath --relative-to="$SO_DIR" "$LIB_DIR")
-        echo "    🩹 Patching $(realpath --relative-to="$RUBY_PREFIX" "$ext_so") to rpath: \$ORIGIN/$REL_RPATH"
-        patchelf --set-rpath "\$ORIGIN/$REL_RPATH" "$ext_so"
-
-        ldd "$ext_so" | awk '/=>/ { print $3 }' | while read -r dep; do
-            if [[ -f "$dep" ]]; then
-                dest="$LIB_DIR/$(basename $dep)"
+    ldd "$RUBY_PREFIX/bin/ruby" | awk '/=>/ { print $3 }' | while read -r filepath; do
+        [[ -z "$filepath" || ! -f "$filepath" ]] && continue
+        
+        filename=$(basename "$filepath")
+        
+        # explicitly skip system libraries
+        [[ "$filename" =~ ^(libc\.so|libm\.so|libdl\.so|libcrypt\.so|librt\.so|libpthread\.so|ld-linux.*\.so).* ]] && continue
+        
+        for prefix in "${WHITELISTED_LIBS[@]}"; do
+            if [[ "$filename" == "$prefix"* ]]; then
+                dest="$LIB_DIR/$filename"
                 if [[ ! -f "$dest" ]]; then
-                    echo "    📝 Copying $dep"
-                    cp -u "$dep" "$LIB_DIR/"
+                    echo "    📝 Copying $filepath"
+                    cp -aL "$filepath" "$LIB_DIR/"
                 fi
+                break
             fi
         done
     done
-    echo "✅ All shared library paths rewritten using @rpath where applicable."
+
+    echo "  🐧 Patching portable Ruby bundle for Linux"
+    patchelf --set-rpath '$ORIGIN/../lib' "$RUBY_PREFIX/bin/ruby"
 fi
 
 echo "✂️ Stripping symbols and measuring size savings..."

--- a/packages/fpm/build.sh
+++ b/packages/fpm/build.sh
@@ -12,22 +12,22 @@ if [ "$OS_TARGET" = "darwin" ]; then
     bash "$CWD/assets/patch-portable-ruby.sh"
 else
     # These are the --platform linux/ARCH options available
-    # Pulled from: https://hub.docker.com/_/buildpack-deps/tags?name=22.04-curl
-    ARCH_OPTIONS="x86_64 arm/v5 arm/v7 arm64/v8 i386 mips64le ppc64le s390x"
+    # Pulled from: https://hub.docker.com/_/debian/tags?name=buster
+    ARCH_OPTIONS="i386 amd64 arm/v5 arm/v7 arm64/v8"
     echo "Building for Linux"
     if [ -z "$ARCH" ]; then
         echo "Architecture not specified. Options are: $ARCH_OPTIONS."
-        ARCH="x86_64"
+        ARCH="amd64"
         echo "Defaulting to $ARCH."
     fi
     if [[ "$ARCH_OPTIONS" != *"$ARCH"* ]]; then
         echo "Unknown architecture: $ARCH. Options supported: $ARCH_OPTIONS."
         echo "Please set the ARCH environment variable to one of these values."
-        echo "Example: ARCH=x86_64 ./path/to/build.sh"
+        echo "Example: ARCH=amd64 ./path/to/build.sh"
         exit 1
     fi
     if [ "$ARCH" = "i386" ]; then
-        PLATFORM_ARCH="x86_64" # for --platform=linux/x86_64 multi-arch image compiling 32-bit
+        PLATFORM_ARCH="386"
     else
         PLATFORM_ARCH="$ARCH"
     fi
@@ -63,14 +63,13 @@ else
     DOCKER_TAG="fpm-builder:$ARCH_KEY"
     docker buildx build \
         --load \
-        -f "$CWD/assets/Dockerfile" \
         --build-arg PLATFORM_ARCH=$PLATFORM_ARCH \
         --build-arg TARGET_ARCH=$ARCH \
         --build-arg RUBY_VERSION=$RUBY_VERSION \
         --progress=plain \
+        -f "$CWD/assets/Dockerfile" \
         -t $DOCKER_TAG \
         $CWD
-    # --no-cache \ # Add to above to force rebuild
     docker run --cidfile="$cidFile" $DOCKER_TAG
 
     containerId=$(cat "$cidFile")


### PR DESCRIPTION
fix(fpm): Downgrade docker image to debian:buster to support older distro versions for fpm.

This should now provide support for the following (per GPT):

Debian 10, 11, 12
Ubuntu 18.04, 20.04, 22.04+
CentOS 8+
Amazon Linux 2+

Verified integration through electron-builder CI in https://github.com/electron-userland/electron-builder/pull/9100