### PR TITLE
fix(appimage): exclude libm from AppImage build process

### DIFF
--- a/.changeset/shiny-rivers-turn.md
+++ b/.changeset/shiny-rivers-turn.md
@@ -1,0 +1,5 @@
+---
+"appimage": patch
+---
+
+fix(appimage): exclude libm from AppImage build process

--- a/packages/appimage/assets/build-appimage.sh
+++ b/packages/appimage/assets/build-appimage.sh
@@ -310,7 +310,7 @@ find "$ARCH_OUTPUT_DIR" -type f -perm -111 | while read -r binary; do
             
             # Skip system libraries
             case "$libname" in
-                libc.so.*|ld-linux*.so.*|libpthread.so.*|librt.so.*|libdl.so.*)
+                libc.so.*|libm.so.*|libm-*.so|ld-linux*.so.*|libpthread.so.*|librt.so.*|libdl.so.*)
                     continue
                 ;;
             esac


### PR DESCRIPTION
`libm.so.6` and `libm-2.27.so` are part of libc.
Removing them from the bundle will fix electron-userland/electron-builder#9598 .