### PR TITLE
chore: Adding Licensing to repo and including LICENSE/COPYING in toolset artifacts

### DIFF
--- a/.changeset/fresh-comics-tap.md
+++ b/.changeset/fresh-comics-tap.md
@@ -1,0 +1,11 @@
+---
+"squirrel.windows": patch
+"win-codesign": patch
+"dmg-builder": patch
+"appimage": patch
+"nsis": patch
+"fpm": patch
+"ran": patch
+---
+
+chore: embedding LICENSE/COPYING files within each toolset bundle

--- a/.github/workflows/build-fpm.yaml
+++ b/.github/workflows/build-fpm.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           pnpm i --frozen-lockfile
           export ARCH=${{ matrix.arch }}
-          bash build-linux.sh
+          bash packages/fpm/build.sh
           echo "ARCH_KEY=$(echo $ARCH | tr '/' '-')" >> $GITHUB_ENV
       - name: Upload FPM Linux artifact
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1

--- a/README.md
+++ b/README.md
@@ -4,15 +4,18 @@ This repo provides the required toolsets that [electron-builder](http://github.c
 
 The toolset (in Releases) have their version and checksum hardcoded in electron-builder's code. This ensures that even if this repository or your network gets compromised, electron-builder tooling will not be affected.
 
-The goal of this repo is to provide a secure closed-loop tooling ecosystem that electron-builder can rely on.
+The goals of this repo are:
+- To provide a secure closed-loop tooling ecosystem that electron-builder can rely on.
+- Serve toolsets on-demand to reduce (or remove entirely) the load/overhead of a pre-configuring a dev environment.
 
 ## Licensing
 
 ### Artifacts
 
-All toolsets collected/stored/distributed from this repo retain their original licensing; their LICENSE or COPYING file(s) are downloaded and included within each toolset bundle within `artifacts` dir. The scripts and supporting files that packages these distributables are under MIT.
+All toolsets collected/stored/distributed from this repo retain their original licensing; their LICENSE or COPYING file(s) are downloaded and included within each toolset bundle within `artifacts` dir.
 
 ### Repo License
+This applies to configurations/scripts that compile and/or bundle toolsets.
 
 Copyright 2026 electron-userland
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # electron-builder-binaries
 
-[electron-builder](http://github.com/electron-userland/electron-builder) downloads required tools files on demand (e.g. to code sign windows application, to make AppX).
+This repo provides the required toolsets that [electron-builder](http://github.com/electron-userland/electron-builder) downloads on demand (e.g. to code sign windows application, to make AppX, assemble DMGs, bundle AppImage, etc).
 
-Version and SHA512 checksum of binary is hardcoded in the electron-builder code. So, even if this repository will be compromised, users are not affected.
+The toolset (in Releases) have their version and checksum hardcoded in electron-builder's code. This ensures that even if this repository or your network gets compromised, electron-builder tooling will not be affected.
+
+The goal of this repo is to provide a secure closed-loop tooling ecosystem that electron-builder can rely on.
+
+## Licensing
+
+### Artifacts
+
+All toolsets collected/stored/distributed from this repo retain their original licensing; their LICENSE or COPYING file(s) are downloaded and included within each toolset bundle within `artifacts` dir. The scripts and supporting files that packages these distributables are under MIT.
+
+### Repo License
+
+Copyright 2026 electron-userland
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/appimage/assets/bundle-and-compress.sh
+++ b/packages/appimage/assets/bundle-and-compress.sh
@@ -179,6 +179,18 @@ done
 echo "✅ Generic AppImage tool wrapper created"
 
 # =============================
+# Download component licenses
+# =============================
+echo ""
+echo "📄 Downloading component licenses..."
+mkdir -p "$BUILD_DIR/LICENSES"
+curl -fsSL "https://raw.githubusercontent.com/AppImage/AppImageKit/master/LICENSE" \
+  -o "$BUILD_DIR/LICENSES/LICENSE.AppImageKit"
+curl -fsSL "https://raw.githubusercontent.com/AppImage/type2-runtime/main/LICENSE" \
+  -o "$BUILD_DIR/LICENSES/LICENSE.type2-runtime"
+echo "✅ Licenses downloaded"
+
+# =============================
 # Create final tar.gz bundle
 # =============================
 echo ""

--- a/packages/appimage/assets/download-runtime.sh
+++ b/packages/appimage/assets/download-runtime.sh
@@ -167,11 +167,6 @@ echo "AppImage/type2-runtime release: $APPIMAGE_TYPE2_RELEASE" > "$INSTALL_DIR/V
 echo "$CHECKSUMS" >> "$INSTALL_DIR/VERSION.txt"
 echo "All files verified successfully." >&2
 
-# Download AppImage type2-runtime LICENSE
-echo "📄 Downloading LICENSE..." >&2
-curl -fsSL "https://raw.githubusercontent.com/AppImage/type2-runtime/main/LICENSE" \
-  -o "$INSTALL_DIR/LICENSE"
-
 ARCHIVE_NAME="appimage-runtime-$APPIMAGE_TYPE2_RELEASE.tar.gz"
 echo "📦 Creating tar.gz bundle: $ARCHIVE_NAME"
 (

--- a/packages/appimage/assets/download-runtime.sh
+++ b/packages/appimage/assets/download-runtime.sh
@@ -167,6 +167,11 @@ echo "AppImage/type2-runtime release: $APPIMAGE_TYPE2_RELEASE" > "$INSTALL_DIR/V
 echo "$CHECKSUMS" >> "$INSTALL_DIR/VERSION.txt"
 echo "All files verified successfully." >&2
 
+# Download AppImage type2-runtime LICENSE
+echo "📄 Downloading LICENSE..." >&2
+curl -fsSL "https://raw.githubusercontent.com/AppImage/type2-runtime/main/LICENSE" \
+  -o "$INSTALL_DIR/LICENSE"
+
 ARCHIVE_NAME="appimage-runtime-$APPIMAGE_TYPE2_RELEASE.tar.gz"
 echo "📦 Creating tar.gz bundle: $ARCHIVE_NAME"
 (

--- a/packages/dmg-builder/assets/build-python-runtime.sh
+++ b/packages/dmg-builder/assets/build-python-runtime.sh
@@ -90,8 +90,7 @@ file "$PREFIX/bin/python3"
 echo "🐍 Installing pip and dmgbuild"
 
 run_arch "$PREFIX/bin/python3" -m pip install --upgrade pip --no-warn-script-location --no-cache 
-run_arch "$PREFIX/bin/python3" -m pip install --no-warn-script-location --no-cache git+https://github.com/dmgbuild/dmgbuild.git@${DMGBUILD_VERSION}
-run_arch "$PREFIX/bin/python3" -m pip install --no-warn-script-location --no-cache git+https://github.com/dmgbuild/dmgbuild.git@${DMGBUILD_VERSION}#egg=dmgbuild[badge_icons]
+run_arch "$PREFIX/bin/python3" -m pip install --no-warn-script-location --no-cache "dmgbuild[badge_icons] @ git+https://github.com/dmgbuild/dmgbuild.git@${DMGBUILD_VERSION}"
 
 ###############################################################################
 # ADD VERSION.txt FILE with python version and versions of each major package
@@ -232,7 +231,7 @@ codesign --force  \
 
 echo "📄 Downloading component licenses..."
 mkdir -p "${DIR_TO_ARCHIVE}/LICENSES"
-curl -fsSL "https://raw.githubusercontent.com/al45tair/dmgbuild/master/LICENSE" \
+curl -fsSL "https://raw.githubusercontent.com/dmgbuild/dmgbuild/master/LICENSE" \
   -o "${DIR_TO_ARCHIVE}/LICENSES/LICENSE.dmgbuild"
 if [ ! -f "${DIR_TO_ARCHIVE}/python/LICENSE.txt" ]; then
   curl -fsSL "https://raw.githubusercontent.com/python/cpython/v${PYTHON_VERSION}/LICENSE" \

--- a/packages/dmg-builder/assets/build-python-runtime.sh
+++ b/packages/dmg-builder/assets/build-python-runtime.sh
@@ -230,6 +230,16 @@ codesign --force  \
 # ARCHIVE (do it now to avoid including later test and cache files)
 ###############################################################################
 
+echo "📄 Downloading component licenses..."
+mkdir -p "${DIR_TO_ARCHIVE}/LICENSES"
+curl -fsSL "https://raw.githubusercontent.com/al45tair/dmgbuild/master/LICENSE" \
+  -o "${DIR_TO_ARCHIVE}/LICENSES/LICENSE.dmgbuild"
+if [ ! -f "${DIR_TO_ARCHIVE}/python/LICENSE.txt" ]; then
+  curl -fsSL "https://raw.githubusercontent.com/python/cpython/v${PYTHON_VERSION}/LICENSE" \
+    -o "${DIR_TO_ARCHIVE}/LICENSES/LICENSE.python"
+fi
+echo "  ✓ Licenses downloaded"
+
 echo "📦 Creating archive…"
 cd "${DIR_TO_ARCHIVE}"
 

--- a/packages/fpm/assets/patch-portable-ruby.sh
+++ b/packages/fpm/assets/patch-portable-ruby.sh
@@ -292,6 +292,18 @@ fi
 echo "$RUBY_VERSION_VERBOSE" >$INSTALL_DIR/VERSION.txt
 echo "fpm: $FPM_VERSION" >>$INSTALL_DIR/VERSION.txt
 
+echo "📄 Downloading component licenses..."
+mkdir -p "$INSTALL_DIR/LICENSES"
+curl -fsSL "https://raw.githubusercontent.com/jordansissel/fpm/master/LICENSE" \
+  -o "$INSTALL_DIR/LICENSES/LICENSE.fpm"
+if [ -f "$RUBY_PREFIX/COPYING" ]; then
+  cp "$RUBY_PREFIX/COPYING" "$INSTALL_DIR/LICENSES/LICENSE.ruby"
+else
+  curl -fsSL "https://raw.githubusercontent.com/ruby/ruby/master/COPYING" \
+    -o "$INSTALL_DIR/LICENSES/LICENSE.ruby"
+fi
+echo "  ✓ Licenses downloaded"
+
 echo "🔨 Creating portable archive..."
 cd "$INSTALL_DIR"
 

--- a/packages/nsis/assets/nsis-combine.sh
+++ b/packages/nsis/assets/nsis-combine.sh
@@ -389,6 +389,16 @@ EOF
 echo "  ✓ VERSION.txt updated"
 
 # =============================================================================
+# Download NSIS License
+# =============================================================================
+
+echo ""
+echo "📄 Downloading NSIS LICENSE..."
+curl -fsSL "https://raw.githubusercontent.com/kichik/nsis/v${NSIS_VERSION}/COPYING" \
+  -o "$BUILD_DIR/nsis-bundle/LICENSE"
+echo "  ✓ LICENSE downloaded"
+
+# =============================================================================
 # Create Final Archive
 # =============================================================================
 

--- a/packages/nsis/assets/nsis-combine.sh
+++ b/packages/nsis/assets/nsis-combine.sh
@@ -394,7 +394,7 @@ echo "  ✓ VERSION.txt updated"
 
 echo ""
 echo "📄 Downloading NSIS LICENSE..."
-curl -fsSL "https://raw.githubusercontent.com/kichik/nsis/v${NSIS_VERSION}/COPYING" \
+curl -fsSL "https://raw.githubusercontent.com/kichik/nsis/master/COPYING" \
   -o "$BUILD_DIR/nsis-bundle/LICENSE"
 echo "  ✓ LICENSE downloaded"
 

--- a/packages/ran/assets/build.sh
+++ b/packages/ran/assets/build.sh
@@ -133,6 +133,11 @@ done
 echo "📝 Creating VERSION.txt..."
 echo "$VERSION" > "$OUTPUT_DIR/VERSION.txt"
 
+# Download RAN LICENSE
+echo "📄 Downloading LICENSE..."
+curl -fsSL "https://raw.githubusercontent.com/m3ng9i/ran/${VERSION}/LICENSE" \
+  -o "$OUTPUT_DIR/LICENSE"
+
 # Create final ZIP bundle
 ARCHIVE_NAME="ran-${VERSION}-all-platforms.zip"
 

--- a/packages/squirrel.windows/build.ps1
+++ b/packages/squirrel.windows/build.ps1
@@ -73,7 +73,8 @@ if (Test-Path $licenseSrc) {
     Copy-Item $licenseSrc -Destination $licenseDest -Force
     Write-Host "`n✅ LICENSE copied to vendor directory"
 } else {
-    Write-Warning "`n⚠️ LICENSE not found in cloned repo at $licenseSrc"
+    Write-Error "`n⚠️ LICENSE not found in cloned repo at $licenseSrc"
+    exit 1
 }
 
 # --- Ensure output directory exists

--- a/packages/squirrel.windows/build.ps1
+++ b/packages/squirrel.windows/build.ps1
@@ -66,6 +66,16 @@ foreach ($src in $copyMap.Keys) {
 
 Write-Host "`n✅ Build completed successfully!"
 
+# --- Copy LICENSE from cloned repo before cleanup
+$licenseSrc = Join-Path $repoRoot "LICENSE"
+$licenseDest = Join-Path $vendorDir "LICENSE"
+if (Test-Path $licenseSrc) {
+    Copy-Item $licenseSrc -Destination $licenseDest -Force
+    Write-Host "`n✅ LICENSE copied to vendor directory"
+} else {
+    Write-Warning "`n⚠️ LICENSE not found in cloned repo at $licenseSrc"
+}
+
 # --- Ensure output directory exists
 if (-not (Test-Path $artifactDir)) {
     New-Item -ItemType Directory -Path $artifactDir -Force | Out-Null

--- a/packages/win-codesign/assets/build-win-rcedit.sh
+++ b/packages/win-codesign/assets/build-win-rcedit.sh
@@ -35,6 +35,10 @@ curl -L "https://github.com/electron/rcedit/releases/download/v$RCEDIT_VERSION/r
     echo "$($RCEDIT_BUNDLE_DIR/rcedit-x64.exe "$RCEDIT_BUNDLE_DIR/rcedit-x86.exe" --get-version-string "FileVersion")"
 } > "$RCEDIT_BUNDLE_DIR/VERSION.txt"
 
+echo "📄 Downloading rcedit LICENSE..."
+curl -fsSL "https://raw.githubusercontent.com/electron/rcedit/master/LICENSE" \
+  -o "$RCEDIT_BUNDLE_DIR/LICENSE"
+
 echo "📦 Zipping rcedit bundle..."
 cd "$RCEDIT_BUNDLE_DIR"
 zip -r -9 "$RCEDIT_ZIP" .

--- a/packages/win-codesign/assets/bundle-osslsigncode.sh
+++ b/packages/win-codesign/assets/bundle-osslsigncode.sh
@@ -123,7 +123,7 @@ ARCHIVE_ARCH_SUFFIX=$(echo ${PLATFORM_ARCH:-$(uname -m)} | tr -d '/' | tr '[:upp
 ARCHIVE_NAME="win-codesign-$(uname -s | tr A-Z a-z)-$ARCHIVE_ARCH_SUFFIX.zip"
 
 echo "📄 Downloading osslsigncode LICENSE..."
-curl -fsSL "https://raw.githubusercontent.com/mtrojnar/osslsigncode/main/LICENSE.md" \
+curl -fsSL "https://raw.githubusercontent.com/mtrojnar/osslsigncode/master/LICENSE" \
   -o "$INSTALL_DIR/LICENSE"
 
 echo "📦 Creating ZIP bundle: $ARCHIVE_NAME"

--- a/packages/win-codesign/assets/bundle-osslsigncode.sh
+++ b/packages/win-codesign/assets/bundle-osslsigncode.sh
@@ -123,7 +123,7 @@ ARCHIVE_ARCH_SUFFIX=$(echo ${PLATFORM_ARCH:-$(uname -m)} | tr -d '/' | tr '[:upp
 ARCHIVE_NAME="win-codesign-$(uname -s | tr A-Z a-z)-$ARCHIVE_ARCH_SUFFIX.zip"
 
 echo "📄 Downloading osslsigncode LICENSE..."
-curl -fsSL "https://raw.githubusercontent.com/mtrojnar/osslsigncode/master/LICENSE" \
+curl -fsSL "https://raw.githubusercontent.com/mtrojnar/osslsigncode/master/LICENSE.txt" \
   -o "$INSTALL_DIR/LICENSE"
 
 echo "📦 Creating ZIP bundle: $ARCHIVE_NAME"

--- a/packages/win-codesign/assets/bundle-osslsigncode.sh
+++ b/packages/win-codesign/assets/bundle-osslsigncode.sh
@@ -122,6 +122,10 @@ echo "  - Or run: LD_LIBRARY_PATH=$LIB_DIR OPENSSL_MODULES=$LIB_DIR/ossl-modules
 ARCHIVE_ARCH_SUFFIX=$(echo ${PLATFORM_ARCH:-$(uname -m)} | tr -d '/' | tr '[:upper:]' '[:lower:]')
 ARCHIVE_NAME="win-codesign-$(uname -s | tr A-Z a-z)-$ARCHIVE_ARCH_SUFFIX.zip"
 
+echo "📄 Downloading osslsigncode LICENSE..."
+curl -fsSL "https://raw.githubusercontent.com/mtrojnar/osslsigncode/main/LICENSE.md" \
+  -o "$INSTALL_DIR/LICENSE"
+
 echo "📦 Creating ZIP bundle: $ARCHIVE_NAME"
 (
   cd "$INSTALL_DIR"


### PR DESCRIPTION
## Licensing approach

### Artifacts

All toolsets collected/stored/distributed from this repo retain their original licensing; their LICENSE or COPYING file(s) are downloaded and included within each toolset bundle within `artifacts` dir.

### Repo License => MIT

The scripts and supporting files that package these distributables are under MIT.