### PR TITLE
fix(dmg-builder): fix deployment target to be properly read/applied to builds

### DIFF
--- a/.changeset/tall-groups-talk.md
+++ b/.changeset/tall-groups-talk.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": patch
+---
+
+fix(dmg-builder): fix deployment target to properly read/apply to build pipeline

--- a/packages/dmg-builder/assets/build-python-runtime.sh
+++ b/packages/dmg-builder/assets/build-python-runtime.sh
@@ -29,13 +29,7 @@ run_arch() {
     fi
 }
 
-# NOTE: variable name MUST be MACOSX_DEPLOYMENT_TARGET (with the X).
-# The previous version used MACOS_DEPLOYMENT_TARGET (no X) and then
-# `export MACOSX_DEPLOYMENT_TARGET` re-exported whatever value the CI
-# runner had pre-set (e.g. 15.7 on a macos-15 runner), so the 11.0
-# value here was silently dropped. That is why published binaries
-# advertised "built for macOS 15.7".
-MACOSX_DEPLOYMENT_TARGET="11.0"
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
 BUILD_DIR="${ROOT}/build"
 SRC_DIR="$BUILD_DIR/src"
 TEST_DIR="$BUILD_DIR/test"
@@ -66,16 +60,9 @@ cd Python-${PYTHON_VERSION}
 ### ================================
 ### BUILD ENV (NO HOMEBREW)
 ### ================================
-# Pin to the Xcode SDK so headers/libs come from the SDK only and never
-# from /usr/local (Intel runners) or /opt/homebrew (Apple-silicon
-# runners). The previous version `unset SDKROOT`, which let Apple's ld(64)
-# fall back to its default search list, which on Intel macOS includes
-# /usr/local/lib — that is how Homebrew's gettext (libintl.8.dylib) got
-# linked into _locale.so, baking the path
-# /usr/local/opt/gettext/lib/libintl.8.dylib into the shipped binary.
+# Pin to the Xcode SDK so headers/libs come from the SDK only and never from /usr/local (Intel runners) or /opt/homebrew (Apple-silicon runners). 
 SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
 export SDKROOT
-export MACOSX_DEPLOYMENT_TARGET
 export CC=clang
 export CXX=clang++
 export CFLAGS="-O3 -fPIC -arch ${ARCH} -isysroot ${SDKROOT} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
@@ -86,8 +73,7 @@ export CPATH=""
 
 unset PKG_CONFIG_PATH
 
-# Locate Homebrew OpenSSL. --with-openssl scopes it only to the _ssl extension
-# module, so no other Homebrew library can bleed into the build.
+# Locate Homebrew OpenSSL. --with-openssl scopes it only to the _ssl extension module, so no other Homebrew library can bleed into the build.
 OPENSSL_PREFIX=""
 for candidate in \
     "$(brew --prefix openssl@3 2>/dev/null || true)" \
@@ -109,11 +95,7 @@ echo "🔐 Using OpenSSL at: $OPENSSL_PREFIX"
 ### ================================
 ### CONFIGURE
 ### ================================
-# Force the autoconf cache for libintl/gettext detection to "no" so that
-# even if a stray /usr/local or /opt/homebrew gettext slipped onto the
-# search path, _locale would not link against it. macOS already has
-# everything _locale needs in libSystem; libintl is a Linux-flavour
-# extra that must NOT be picked up here.
+# Force the autoconf cache for libintl/gettext detection to "no" so that# even if a stray /usr/local or /opt/homebrew gettext slipped onto the search path, _locale would not link against it. macOS already has everything _locale needs in libSystem
 run_arch ./configure \
   --prefix="$PREFIX" \
   --enable-optimizations \
@@ -234,9 +216,7 @@ done
 ###############################################################################
 # BUNDLE OPENSSL DYLIBS — rewrite Homebrew paths to @loader_path-relative
 ###############################################################################
-# _ssl.so and _hashlib.so link against Homebrew's libssl/libcrypto. Copy those
-# dylibs into lib-dynload/ alongside the .so files and rewrite every reference
-# so the bundle is self-contained and passes the Homebrew-leak guardrail.
+# _ssl.so and _hashlib.so link against Homebrew's libssl/libcrypto. We copy dylibs into lib-dynload/ alongside the .so files and rewrite every reference so the bundle is self-contained and passes the Homebrew-leak guardrail.
 
 DYNLOAD_DIR="$(find "$PREFIX/lib" -maxdepth 2 -type d -name lib-dynload | head -n 1)"
 

--- a/packages/dmg-builder/assets/build-python-runtime.sh
+++ b/packages/dmg-builder/assets/build-python-runtime.sh
@@ -29,7 +29,13 @@ run_arch() {
     fi
 }
 
-MACOS_DEPLOYMENT_TARGET="11.0"
+# NOTE: variable name MUST be MACOSX_DEPLOYMENT_TARGET (with the X).
+# The previous version used MACOS_DEPLOYMENT_TARGET (no X) and then
+# `export MACOSX_DEPLOYMENT_TARGET` re-exported whatever value the CI
+# runner had pre-set (e.g. 15.7 on a macos-15 runner), so the 11.0
+# value here was silently dropped. That is why published binaries
+# advertised "built for macOS 15.7".
+MACOSX_DEPLOYMENT_TARGET="11.0"
 BUILD_DIR="${ROOT}/build"
 SRC_DIR="$BUILD_DIR/src"
 TEST_DIR="$BUILD_DIR/test"
@@ -40,6 +46,7 @@ echo "🐍 dmgbuild portable bundler"
 echo "📁 Output directory: ${DIR_TO_ARCHIVE}"
 echo "🔢 Python version: ${PYTHON_VERSION}"
 echo "📦 dmgbuild version: ${DMGBUILD_VERSION}"
+echo "🍎 macOS deployment target: ${MACOSX_DEPLOYMENT_TARGET}"
 echo ""
 
 ### ================================
@@ -59,22 +66,63 @@ cd Python-${PYTHON_VERSION}
 ### ================================
 ### BUILD ENV (NO HOMEBREW)
 ### ================================
+# Pin to the Xcode SDK so headers/libs come from the SDK only and never
+# from /usr/local (Intel runners) or /opt/homebrew (Apple-silicon
+# runners). The previous version `unset SDKROOT`, which let Apple's ld(64)
+# fall back to its default search list, which on Intel macOS includes
+# /usr/local/lib — that is how Homebrew's gettext (libintl.8.dylib) got
+# linked into _locale.so, baking the path
+# /usr/local/opt/gettext/lib/libintl.8.dylib into the shipped binary.
+SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+export SDKROOT
 export MACOSX_DEPLOYMENT_TARGET
 export CC=clang
 export CXX=clang++
-export CFLAGS="-O3 -fPIC -arch ${ARCH}"
-export LDFLAGS="-arch ${ARCH}"
+export CFLAGS="-O3 -fPIC -arch ${ARCH} -isysroot ${SDKROOT} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+export LDFLAGS="-arch ${ARCH} -isysroot ${SDKROOT} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+# Belt-and-braces: tell ld(64) explicitly NOT to search Homebrew prefixes.
+export LIBRARY_PATH=""
+export CPATH=""
 
-unset CPATH LIBRARY_PATH PKG_CONFIG_PATH SDKROOT
+unset PKG_CONFIG_PATH
+
+# Locate Homebrew OpenSSL. --with-openssl scopes it only to the _ssl extension
+# module, so no other Homebrew library can bleed into the build.
+OPENSSL_PREFIX=""
+for candidate in \
+    "$(brew --prefix openssl@3 2>/dev/null || true)" \
+    /opt/homebrew/opt/openssl@3 \
+    /usr/local/opt/openssl@3 \
+    /opt/homebrew/opt/openssl \
+    /usr/local/opt/openssl; do
+  if [[ -n "$candidate" && -d "$candidate/include/openssl" ]]; then
+    OPENSSL_PREFIX="$candidate"
+    break
+  fi
+done
+if [[ -z "$OPENSSL_PREFIX" ]]; then
+  echo "❌ OpenSSL not found — install it with: brew install openssl@3"
+  exit 1
+fi
+echo "🔐 Using OpenSSL at: $OPENSSL_PREFIX"
 
 ### ================================
 ### CONFIGURE
 ### ================================
+# Force the autoconf cache for libintl/gettext detection to "no" so that
+# even if a stray /usr/local or /opt/homebrew gettext slipped onto the
+# search path, _locale would not link against it. macOS already has
+# everything _locale needs in libSystem; libintl is a Linux-flavour
+# extra that must NOT be picked up here.
 run_arch ./configure \
---prefix="$PREFIX" \
---enable-optimizations \
---disable-shared \
---disable-test-modules
+  --prefix="$PREFIX" \
+  --enable-optimizations \
+  --disable-shared \
+  --disable-test-modules \
+  --with-openssl="$OPENSSL_PREFIX" \
+  ac_cv_header_libintl_h=no \
+  ac_cv_lib_intl_textdomain=no \
+  ac_cv_lib_intl_libintl_setlocale=no
 
 ### ================================
 ### BUILD & INSTALL
@@ -89,9 +137,8 @@ file "$PREFIX/bin/python3"
 ### ================================
 echo "🐍 Installing pip and dmgbuild"
 
-run_arch "$PREFIX/bin/python3" -m pip install --upgrade pip --no-warn-script-location --no-cache 
-run_arch "$PREFIX/bin/python3" -m pip install --no-warn-script-location --no-cache git+https://github.com/dmgbuild/dmgbuild.git@${DMGBUILD_VERSION}
-run_arch "$PREFIX/bin/python3" -m pip install --no-warn-script-location --no-cache git+https://github.com/dmgbuild/dmgbuild.git@${DMGBUILD_VERSION}#egg=dmgbuild[badge_icons]
+run_arch "$PREFIX/bin/python3" -m pip install --upgrade pip --no-warn-script-location --no-cache
+run_arch "$PREFIX/bin/python3" -m pip install --no-warn-script-location --no-cache "dmgbuild[badge_icons] @ git+https://github.com/dmgbuild/dmgbuild.git@${DMGBUILD_VERSION}"
 
 ###############################################################################
 # ADD VERSION.txt FILE with python version and versions of each major package
@@ -100,6 +147,7 @@ echo "📝 Creating VERSION.txt…"
 {
     echo "dmgbuild version/commit hash: ${DMGBUILD_VERSION}"
     echo "Python version: ${PYTHON_VERSION}"
+    echo "macOS deployment target: ${MACOSX_DEPLOYMENT_TARGET}"
     echo -n "dmgbuild package version: "
     run_arch "$PREFIX/bin/python3" -m pip show dmgbuild | grep ^Version: | awk '{print $2}'
 } > "$DIR_TO_ARCHIVE/VERSION.txt"
@@ -183,6 +231,48 @@ find "$PREFIX/lib" -name "*.so" | while read -r so; do
     add_rpath_if_missing "$so" "@loader_path"
 done
 
+###############################################################################
+# BUNDLE OPENSSL DYLIBS — rewrite Homebrew paths to @loader_path-relative
+###############################################################################
+# _ssl.so and _hashlib.so link against Homebrew's libssl/libcrypto. Copy those
+# dylibs into lib-dynload/ alongside the .so files and rewrite every reference
+# so the bundle is self-contained and passes the Homebrew-leak guardrail.
+
+DYNLOAD_DIR="$(find "$PREFIX/lib" -maxdepth 2 -type d -name lib-dynload | head -n 1)"
+
+bundle_openssl_dylib() {
+    local src="$1"
+    local name
+    name="$(basename "$src")"
+    local dst="$DYNLOAD_DIR/$name"
+    if [[ ! -f "$dst" ]]; then
+        cp "$src" "$dst"
+        install_name_tool -id "@loader_path/$name" "$dst"
+    fi
+}
+
+# Pass 1: copy every Homebrew dylib referenced by .so files into DYNLOAD_DIR
+while IFS= read -r so; do
+    while IFS= read -r ref; do
+        if [[ "$ref" == /opt/homebrew/* || "$ref" == /usr/local/opt/* ]]; then
+            bundle_openssl_dylib "$ref"
+        fi
+    done < <(otool -L "$so" 2>/dev/null | awk 'NR>1 {print $1}')
+done < <(find "$DYNLOAD_DIR" -name "*.so")
+
+# Pass 2: rewrite Homebrew references in both .so and the newly copied .dylib files
+# (dylibs like libssl reference libcrypto via their original Homebrew path)
+while IFS= read -r bin; do
+    while IFS= read -r ref; do
+        if [[ "$ref" == /opt/homebrew/* || "$ref" == /usr/local/opt/* ]]; then
+            local_name="$(basename "$ref")"
+            # If the dependency wasn't already bundled in pass 1, copy it now
+            bundle_openssl_dylib "$ref"
+            install_name_tool -change "$ref" "@loader_path/$local_name" "$bin"
+        fi
+    done < <(otool -L "$bin" 2>/dev/null | awk 'NR>1 {print $1}')
+done < <(find "$DYNLOAD_DIR" \( -name "*.so" -o -name "*.dylib" \))
+
 # ###############################################################################
 # # ENTRYPOINT SCRIPT
 # ###############################################################################
@@ -219,12 +309,42 @@ find "$DIR_TO_ARCHIVE" -type f \
 --sign "$CODESIGN_IDENTITY" \
 {} \;
 
-codesign --force  \
+codesign --force \
 --sign "$CODESIGN_IDENTITY" \
 "$DIR_TO_ARCHIVE/python/bin/python3"
-codesign --force  \
+codesign --force \
 --sign "$CODESIGN_IDENTITY" \
 "$DIR_TO_ARCHIVE/dmgbuild"
+
+###############################################################################
+# GUARDRAILS — fail the build if Homebrew leaked or deployment target is wrong
+###############################################################################
+echo "🔎 Asserting no Homebrew leak and correct deployment target"
+
+# 1) No Mach-O in the bundle may reference /usr/local/... or /opt/homebrew/...
+LEAKS=""
+while IFS= read -r f; do
+    refs=$(otool -L "$f" 2>/dev/null \
+        | awk 'NR>1 {print $1}' \
+        | grep -E '^(/usr/local/|/opt/homebrew/)' || true)
+    if [ -n "$refs" ]; then
+        LEAKS+=$'\n'"$f:"$'\n'"$refs"
+    fi
+done < <(find "$DIR_TO_ARCHIVE" -type f \( -name "*.so" -o -name "*.dylib" -o -perm +111 \))
+
+if [ -n "$LEAKS" ]; then
+    echo "❌ Homebrew dylib reference leaked into binary:${LEAKS}"
+    exit 1
+fi
+
+# 2) python3 must advertise minos == MACOSX_DEPLOYMENT_TARGET
+VTOUT="$(vtool -show-build "$DIR_TO_ARCHIVE/python/bin/python3" 2>/dev/null || true)"
+if ! echo "$VTOUT" | grep -Eq "minos[[:space:]]+${MACOSX_DEPLOYMENT_TARGET}([. ]|$)"; then
+    echo "❌ python3 deployment target != ${MACOSX_DEPLOYMENT_TARGET}:"
+    echo "$VTOUT"
+    exit 1
+fi
+echo "✅ Guardrails passed (no Homebrew refs, minos=${MACOSX_DEPLOYMENT_TARGET})"
 
 ###############################################################################
 # ARCHIVE (do it now to avoid including later test and cache files)

--- a/packages/dmg-builder/assets/build-python-runtime.sh
+++ b/packages/dmg-builder/assets/build-python-runtime.sh
@@ -9,12 +9,36 @@ fi
 ### ================================
 ### CONFIG
 ### ================================
-ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
-OUTPUT_DIR="${2:-${ROOT}/dist}"
-PYTHON_VERSION="${3:-3.11.8}"
-DMGBUILD_VERSION="${4:-1.6.6}"
-CODESIGN_IDENTITY="${5:-"-"}" # "-" = ad-hoc
-ARCH="${6:-$(uname -m)}"
+_DEFAULT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT=""
+OUTPUT_DIR=""
+PYTHON_VERSION=""
+DMGBUILD_VERSION=""
+CODESIGN_IDENTITY="-"
+ARCH=""
+
+usage() {
+    echo "Usage: $0 --root <dir> --output-dir <dir> --python-version <ver> --dmgbuild-version <ver> [--codesign-identity <id>] [--arch <arm64|x86_64>]"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --root)              ROOT="$2";              shift 2 ;;
+        --output-dir)        OUTPUT_DIR="$2";        shift 2 ;;
+        --python-version)    PYTHON_VERSION="$2";    shift 2 ;;
+        --dmgbuild-version)  DMGBUILD_VERSION="$2";  shift 2 ;;
+        --codesign-identity) CODESIGN_IDENTITY="$2"; shift 2 ;;
+        --arch)              ARCH="$2";              shift 2 ;;
+        *) echo "Unknown argument: $1"; usage ;;
+    esac
+done
+
+ROOT="${ROOT:-$_DEFAULT_ROOT}"
+OUTPUT_DIR="${OUTPUT_DIR:-${ROOT}/dist}"
+PYTHON_VERSION="${PYTHON_VERSION:-3.11.8}"
+DMGBUILD_VERSION="${DMGBUILD_VERSION:-1.6.6}"
+ARCH="${ARCH:-$(uname -m)}"
 
 if [[ "$ARCH" != "arm64" && "$ARCH" != "x86_64" ]]; then
     echo "❌ Unsupported ARCH: $ARCH"

--- a/packages/dmg-builder/assets/build-python-runtime.sh
+++ b/packages/dmg-builder/assets/build-python-runtime.sh
@@ -251,10 +251,15 @@ bundle_openssl_dylib() {
     fi
 }
 
+is_homebrew_path() {
+    local p="$1"
+    [[ "$p" == /opt/homebrew/* || "$p" == /usr/local/opt/* || "$p" == /usr/local/Cellar/* || "$p" == /usr/local/lib/lib* ]]
+}
+
 # Pass 1: copy every Homebrew dylib referenced by .so files into DYNLOAD_DIR
 while IFS= read -r so; do
     while IFS= read -r ref; do
-        if [[ "$ref" == /opt/homebrew/* || "$ref" == /usr/local/opt/* ]]; then
+        if is_homebrew_path "$ref"; then
             bundle_openssl_dylib "$ref"
         fi
     done < <(otool -L "$so" 2>/dev/null | awk 'NR>1 {print $1}')
@@ -264,7 +269,7 @@ done < <(find "$DYNLOAD_DIR" -name "*.so")
 # (dylibs like libssl reference libcrypto via their original Homebrew path)
 while IFS= read -r bin; do
     while IFS= read -r ref; do
-        if [[ "$ref" == /opt/homebrew/* || "$ref" == /usr/local/opt/* ]]; then
+        if is_homebrew_path "$ref"; then
             local_name="$(basename "$ref")"
             # If the dependency wasn't already bundled in pass 1, copy it now
             bundle_openssl_dylib "$ref"

--- a/packages/dmg-builder/build.sh
+++ b/packages/dmg-builder/build.sh
@@ -3,25 +3,92 @@ set -euo pipefail
 
 # CONFIG
 PYTHON_VERSION="3.14.2"
-# https://github.com/dmgbuild/dmgbuild
-# base: v1.6.7
-DMGBUILD_VERSION_OR_HASH="75c8a6c" # commit 75c8a6c7835c5b73dfd4510d92a8f357f93a5fbf
+# https://github.com/dmgbuild/dmgbuild — base: v1.6.7
+DMGBUILD_VERSION_OR_HASH="75c8a6c"
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-
 OUTPUT_DIR="${ROOT}/out/dmg-builder"
+
+# Lowest macOS we promise to support. Must match the runtime's
+# MACOSX_DEPLOYMENT_TARGET inside build-python-runtime.sh.
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
 
 rm -rf "${OUTPUT_DIR}"
 mkdir -p "${OUTPUT_DIR}"
 
-# Default to current architecture
-# can also be space-separated list, e.g. "x86_64 arm64"
+# ─── Homebrew quarantine ─────────────────────────────────────────────────
+# The 14.8 dyld failure (libintl.8.dylib built for macOS 15.7) was caused
+# by Python's ./configure linking against Homebrew's gettext on the build
+# host. Strip every Homebrew leak before we even start.
+sanitize_path() {
+  local IFS=':' p out=()
+  for p in $PATH; do
+    case "$p" in
+      /usr/local/*|/opt/homebrew/*) ;;   # drop
+      *) out+=("$p") ;;
+    esac
+  done
+  ( IFS=':'; echo "${out[*]}" )
+}
+export PATH="$(sanitize_path)"
+unset CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH \
+      LIBRARY_PATH DYLD_LIBRARY_PATH DYLD_FALLBACK_LIBRARY_PATH \
+      PKG_CONFIG_PATH PKG_CONFIG_LIBDIR \
+      SDKROOT HOMEBREW_PREFIX HOMEBREW_CELLAR HOMEBREW_REPOSITORY
+
+# Force clang to ignore /usr/local and /opt/homebrew even if a default
+# search path puts them back. -isysroot pins headers to the SDK only.
+SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
+export CFLAGS="${CFLAGS:-} -isysroot ${SDK_PATH} -nostdinc -isystem ${SDK_PATH}/usr/include -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+export LDFLAGS="${LDFLAGS:-} -isysroot ${SDK_PATH} -Wl,-syslibroot,${SDK_PATH} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+
+# Default to current architecture; can also be "x86_64 arm64"
 ARCHS=${1:-"$(uname -m)"}
 
 for ARCH in $ARCHS; do
-    echo ""
-    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "🏗️  Building Python runtime for ${ARCH}"
-    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    bash "$ROOT/assets/build-python-runtime.sh" "$ROOT" "$OUTPUT_DIR" $PYTHON_VERSION $DMGBUILD_VERSION_OR_HASH "-" "${ARCH}"
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "🏗️  Building Python runtime for ${ARCH}"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  bash "$ROOT/assets/build-python-runtime.sh" \
+    "$ROOT" "$OUTPUT_DIR" "$PYTHON_VERSION" "$DMGBUILD_VERSION_OR_HASH" "-" "${ARCH}"
 done
+
+# ─── Post-build verification ─────────────────────────────────────────────
+# Refuse to publish an artifact that references Homebrew paths or whose
+# embedded minos is newer than our deployment target. This is the gate
+# that would have caught dmg-builder@1.2.0 before release.
+echo ""
+echo "🔎 Verifying artifact has no Homebrew leaks and minos<=${MACOSX_DEPLOYMENT_TARGET}"
+
+bad=0
+FILELIST="$(mktemp)"
+find "${OUTPUT_DIR}" \( -name '*.dylib' -o -name '*.so' -o -perm -u+x -type f \) -print0 > "$FILELIST"
+while IFS= read -r -d '' f; do
+  # Only inspect Mach-O files
+  file "$f" | grep -qE 'Mach-O|dynamically linked' || continue
+
+  if otool -L "$f" 2>/dev/null | grep -E '/usr/local/|/opt/homebrew/' >/tmp/leak.$$; then
+    echo "❌ Homebrew dependency in $f:"
+    sed 's/^/    /' /tmp/leak.$$
+    bad=1
+  fi
+
+  minos=$(otool -l "$f" 2>/dev/null \
+            | awk '/LC_BUILD_VERSION|LC_VERSION_MIN_MACOSX/{f=1} f && /minos|version/{print $2; f=0}' \
+            | head -n1)
+  if [ -n "${minos:-}" ]; then
+    # numeric compare on "X.Y"
+    awk -v a="$minos" -v b="$MACOSX_DEPLOYMENT_TARGET" \
+        'BEGIN{split(a,A,"."); split(b,B,"."); \
+               if (A[1]+0>B[1]+0 || (A[1]+0==B[1]+0 && A[2]+0>B[2]+0)) exit 1}' \
+      || { echo "❌ $f has minos=$minos > ${MACOSX_DEPLOYMENT_TARGET}"; bad=1; }
+  fi
+done < "$FILELIST"
+
+rm -f /tmp/leak.$$ "$FILELIST"
+if [ "$bad" -ne 0 ]; then
+  echo "🛑 Build rejected — fix the leaks above before publishing."
+  exit 1
+fi
+echo "✅ Artifact is clean."

--- a/packages/dmg-builder/build.sh
+++ b/packages/dmg-builder/build.sh
@@ -38,8 +38,22 @@ SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
 export CFLAGS="${CFLAGS:-} -isysroot ${SDK_PATH} -nostdinc -isystem ${SDK_PATH}/usr/include -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
 export LDFLAGS="${LDFLAGS:-} -isysroot ${SDK_PATH} -Wl,-syslibroot,${SDK_PATH} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
 
-# Default to current architecture; can also be "x86_64 arm64"
-ARCHS=${1:-"$(uname -m)"}
+ARCHS=""
+
+usage() {
+  echo "Usage: $0 [--arch <arm64|x86_64>] [--arch <...>]"
+  echo "  --arch   Target architecture (may be repeated; defaults to current machine arch)"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arch) ARCHS="${ARCHS:+$ARCHS }$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; usage ;;
+  esac
+done
+
+ARCHS="${ARCHS:-$(uname -m)}"
 
 for ARCH in $ARCHS; do
   echo ""
@@ -47,7 +61,12 @@ for ARCH in $ARCHS; do
   echo "🏗️  Building Python runtime for ${ARCH}"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   bash "$ROOT/assets/build-python-runtime.sh" \
-    "$ROOT" "$OUTPUT_DIR" "$PYTHON_VERSION" "$DMGBUILD_VERSION_OR_HASH" "-" "${ARCH}"
+    --root "$ROOT" \
+    --output-dir "$OUTPUT_DIR" \
+    --python-version "$PYTHON_VERSION" \
+    --dmgbuild-version "$DMGBUILD_VERSION_OR_HASH" \
+    --codesign-identity "-" \
+    --arch "${ARCH}"
 done
 
 # ─── Post-build verification ─────────────────────────────────────────────

--- a/packages/dmg-builder/build.sh
+++ b/packages/dmg-builder/build.sh
@@ -4,22 +4,19 @@ set -euo pipefail
 # CONFIG
 PYTHON_VERSION="3.14.2"
 # https://github.com/dmgbuild/dmgbuild — base: v1.6.7
+# commit 75c8a6c7835c5b73dfd4510d92a8f357f93a5fbf
 DMGBUILD_VERSION_OR_HASH="75c8a6c"
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 OUTPUT_DIR="${ROOT}/out/dmg-builder"
 
-# Lowest macOS we promise to support. Must match the runtime's
-# MACOSX_DEPLOYMENT_TARGET inside build-python-runtime.sh.
+# Lowest macOS we promise to support
 export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
 
 rm -rf "${OUTPUT_DIR}"
 mkdir -p "${OUTPUT_DIR}"
 
-# ─── Homebrew quarantine ─────────────────────────────────────────────────
-# The 14.8 dyld failure (libintl.8.dylib built for macOS 15.7) was caused
-# by Python's ./configure linking against Homebrew's gettext on the build
-# host. Strip every Homebrew leak before we even start.
+# ─── Homebrew quarantine/avoidance ─────────────────────────────────────────────────
 sanitize_path() {
   local IFS=':' p out=()
   for p in $PATH; do
@@ -36,8 +33,7 @@ unset CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH \
       PKG_CONFIG_PATH PKG_CONFIG_LIBDIR \
       SDKROOT HOMEBREW_PREFIX HOMEBREW_CELLAR HOMEBREW_REPOSITORY
 
-# Force clang to ignore /usr/local and /opt/homebrew even if a default
-# search path puts them back. -isysroot pins headers to the SDK only.
+# Force clang to ignore /usr/local and /opt/homebrew even if a default search path puts them back. -isysroot pins headers to the SDK only.
 SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
 export CFLAGS="${CFLAGS:-} -isysroot ${SDK_PATH} -nostdinc -isystem ${SDK_PATH}/usr/include -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
 export LDFLAGS="${LDFLAGS:-} -isysroot ${SDK_PATH} -Wl,-syslibroot,${SDK_PATH} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
@@ -55,9 +51,7 @@ for ARCH in $ARCHS; do
 done
 
 # ─── Post-build verification ─────────────────────────────────────────────
-# Refuse to publish an artifact that references Homebrew paths or whose
-# embedded minos is newer than our deployment target. This is the gate
-# that would have caught dmg-builder@1.2.0 before release.
+# Refuse to publish an artifact that references Homebrew paths or whose embedded minOS is newer than our deployment target.
 echo ""
 echo "🔎 Verifying artifact has no Homebrew leaks and minos<=${MACOSX_DEPLOYMENT_TARGET}"
 


### PR DESCRIPTION
Resolves https://github.com/electron-userland/electron-builder/issues/9690

Adds additional verification step to make sure that the bundle is truly portable and not referencing any homebrew libs.