### PR TITLE
fix(appimage, ci): replace `x86_64` archive with `i386` when `TARGETARCH` `i386`

### DIFF
--- a/.changeset/tidy-windows-spend.md
+++ b/.changeset/tidy-windows-spend.md
@@ -1,0 +1,5 @@
+---
+"appimage": patch
+---
+
+chore: replace x86_64 archive with i386 when TARGETARCH i386

--- a/packages/appimage/assets/Dockerfile
+++ b/packages/appimage/assets/Dockerfile
@@ -18,6 +18,7 @@ RUN set -eux; \
         sed -i 's|http://archive.ubuntu.com/ubuntu|http://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list; \
     elif [ "$TARGETARCH" = "386" ]; then \
         echo "🔧 Using archive.ubuntu.com for i386"; \
+        sed -i 's|deb http://archive.ubuntu.com/ubuntu|deb [arch=i386] http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list; \
         sed -i 's|deb http://ports.ubuntu.com/ubuntu-ports|deb [arch=i386] http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list; \
     else \
         echo "🔧 Using archive.ubuntu.com for x86_64"; \


### PR DESCRIPTION
It was an overlook on our part: we need this particular line to enable i386 architecture when the Docker container is x86_64, or else it will default to x86_64.

Thanks for merging my initial PR, btw I'd appreciate if further into the project you could add hashes for stable source tarballs/software/etc, and use HTTPS for unhashed latest ones without version pinning (you can use that curl alias as in some of my commits) 😄
```bash
# Harden curl by default
alias curl='curl --fail --tlsv1.2 --proto "=https" --proto-redir "=https"'
```
Or it works as standalone:
```bash
curl --fail --tlsv1.2 --proto "=https" --proto-redir "=https"' [other flags]
```
