### PR TITLE
chore(appimage): add changeset for appimage `unsquashfs` addition

### DIFF
--- a/.changeset/afraid-regions-glow.md
+++ b/.changeset/afraid-regions-glow.md
@@ -1,0 +1,5 @@
+---
+"appimage": minor
+---
+
+feat(appimage): add unsquashfs to the toolset


### PR DESCRIPTION
Forgot to add a changeset for appimage toolset upgrade.
https://github.com/electron-userland/electron-builder-binaries/pull/160

This PR adds it manually while still going through typical CI/CD/authenticated merge flow.