### PR TITLE
chore(nsis): update base git url of nsis GH repo; resolve FIXME translations

### DIFF
--- a/.changeset/wicked-poems-speak.md
+++ b/.changeset/wicked-poems-speak.md
@@ -1,0 +1,5 @@
+---
+"nsis": patch
+---
+
+chore(nsis): update base git url of nsis GH repo. Resolve translation file FIXMEs

--- a/packages/nsis/assets/nsis-combine.sh
+++ b/packages/nsis/assets/nsis-combine.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 BASE_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 OUT_DIR="${OUT_DIR:-$BASE_DIR/out/nsis}"
-BUILD_DIR="/tmp/nsis-bundle-combine"
+BUILD_DIR="$(mktemp -d)"
 
 # Version info
 NSIS_VERSION=${NSIS_VERSION:-3.11}
@@ -39,7 +39,7 @@ BASE_BUNDLE=$(find "$OUT_DIR" -name "nsis-bundle-base-*.tar.gz" -type f | head -
 LINUX_BUNDLE=$(find "$OUT_DIR" -name "nsis-bundle-linux-*.tar.gz" -type f | head -1)
 
 # Find Mac bundles - may have different architectures
-MAC_BUNDLES=$(find "$OUT_DIR" -name "nsis-bundle-mac-*.tar.gz" -type f)
+mapfile -t MAC_BUNDLES < <(find "$OUT_DIR" -name "nsis-bundle-mac-*.tar.gz" -type f)
 # Debug output
 echo "Searching in: $OUT_DIR"
 echo "Files found:"
@@ -61,8 +61,8 @@ else
     LINUX_BUNDLE=""
 fi
 
-if [ -n "$MAC_BUNDLES" ]; then
-    for mac_bundle in $MAC_BUNDLES; do
+if [ "${#MAC_BUNDLES[@]}" -gt 0 ]; then
+    for mac_bundle in "${MAC_BUNDLES[@]}"; do
         echo "  ✓ macOS:        $(basename "$mac_bundle")"
     done
 else
@@ -114,11 +114,11 @@ fi
 # Inject macOS Binaries
 # =============================================================================
 
-if [ -n "$MAC_BUNDLES" ]; then
+if [ "${#MAC_BUNDLES[@]}" -gt 0 ]; then
     echo ""
     echo "🍎 Injecting macOS binaries..."
-    
-    for mac_bundle in $MAC_BUNDLES; do
+
+    for mac_bundle in "${MAC_BUNDLES[@]}"; do
         TEMP_MAC="$BUILD_DIR/temp-mac-$$"
         mkdir -p "$TEMP_MAC"
         
@@ -395,7 +395,7 @@ echo "  ✓ VERSION.txt updated"
 echo ""
 echo "📄 Downloading NSIS LICENSE..."
 curl -fsSL --retry 3 --retry-delay 2 --max-time 60 \
-  "https://raw.githubusercontent.com/kichik/nsis/master/COPYING" \
+  "https://raw.githubusercontent.com/NSIS-Dev/nsis/${NSIS_BRANCH}/COPYING" \
   -o "$BUILD_DIR/nsis-bundle/LICENSE"
 echo "  ✓ LICENSE downloaded"
 

--- a/packages/nsis/assets/nsis-combine.sh
+++ b/packages/nsis/assets/nsis-combine.sh
@@ -38,8 +38,11 @@ echo "📂 Locating bundle files..."
 BASE_BUNDLE=$(find "$OUT_DIR" -name "nsis-bundle-base-*.tar.gz" -type f | head -1)
 LINUX_BUNDLE=$(find "$OUT_DIR" -name "nsis-bundle-linux-*.tar.gz" -type f | head -1)
 
-# Find Mac bundles - may have different architectures
-mapfile -t MAC_BUNDLES < <(find "$OUT_DIR" -name "nsis-bundle-mac-*.tar.gz" -type f)
+# Find Mac bundles - may have different architectures (bash 3.2-compatible, no mapfile)
+MAC_BUNDLES=()
+while IFS= read -r _line; do
+    [[ -n "$_line" ]] && MAC_BUNDLES+=("$_line")
+done < <(find "$OUT_DIR" -name "nsis-bundle-mac-*.tar.gz" -type f)
 # Debug output
 echo "Searching in: $OUT_DIR"
 echo "Files found:"

--- a/packages/nsis/assets/nsis-lang-fixes/Hungarian.nsh
+++ b/packages/nsis/assets/nsis-lang-fixes/Hungarian.nsh
@@ -47,9 +47,9 @@
 !ifdef MUI_COMPONENTSPAGE | MUI_UNCOMPONENTSPAGE
   ${LangFileString} MUI_INNERTEXT_COMPONENTS_DESCRIPTION_TITLE "Leírás"
   !ifndef NSIS_CONFIG_COMPONENTPAGE_ALTERNATIVE
-    ${LangFileString} MUI_INNERTEXT_COMPONENTS_DESCRIPTION_INFO "Vigye rá az egeret az összetevőre, hogy megtekinthesse a leírását."
+    ${LangFileString} MUI_INNERTEXT_COMPONENTS_DESCRIPTION_INFO "Vigye az egérmutatót az összetevő fölé a leírásának megtekintéséhez."
   !else
-    #FIXME:MUI_INNERTEXT_COMPONENTS_DESCRIPTION_INFO 
+    ${LangFileString} MUI_INNERTEXT_COMPONENTS_DESCRIPTION_INFO "Vigye az egérmutatót az összetevő fölé a leírásának megtekintéséhez."
   !endif
 !endif
 

--- a/packages/nsis/assets/nsis-lang-fixes/Turkish.nsh
+++ b/packages/nsis/assets/nsis-lang-fixes/Turkish.nsh
@@ -49,7 +49,7 @@
   !ifndef NSIS_CONFIG_COMPONENTPAGE_ALTERNATIVE
     ${LangFileString} MUI_INNERTEXT_COMPONENTS_DESCRIPTION_INFO "Bileşenlerin açıklamalarını görmek için imleci bileşen üzerine götürün."
   !else
-    #FIXME:MUI_INNERTEXT_COMPONENTS_DESCRIPTION_INFO
+    ${LangFileString} MUI_INNERTEXT_COMPONENTS_DESCRIPTION_INFO "Bileşenlerin açıklamalarını görmek için imleci bileşen üzerine götürün."
   !endif
 !endif
 

--- a/packages/nsis/assets/nsis-linux.sh
+++ b/packages/nsis/assets/nsis-linux.sh
@@ -14,8 +14,8 @@ BASE_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 OUT_DIR="$BASE_DIR/out/nsis"
 
 # Version configuration
-NSIS_VERSION=${NSIS_VERSION:-3.11}
-NSIS_BRANCH=${NSIS_BRANCH_OR_COMMIT:-v311}
+NSIS_VERSION=${NSIS_VERSION:-3.12}
+NSIS_BRANCH=${NSIS_BRANCH_OR_COMMIT:-v312}
 
 # Docker configuration
 IMAGE_NAME="nsis-linux-builder:${NSIS_BRANCH}"
@@ -66,7 +66,7 @@ DOCKERFILE="$OUT_DIR/Dockerfile.linux"
 cat > "$DOCKERFILE" <<'DOCKERFILE_END'
 FROM ubuntu:22.04
 
-ARG NSIS_BRANCH=v310
+ARG NSIS_BRANCH
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install build dependencies
@@ -80,7 +80,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /build
 
 # Clone NSIS source
-RUN git clone --branch ${NSIS_BRANCH} --depth=1 https://github.com/kichik/nsis.git nsis
+RUN git clone --branch ${NSIS_BRANCH} --depth=1 git@github.com:NSIS-Dev/nsis.git nsis
 
 WORKDIR /build/nsis
 

--- a/packages/nsis/assets/nsis-linux.sh
+++ b/packages/nsis/assets/nsis-linux.sh
@@ -80,7 +80,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /build
 
 # Clone NSIS source
-RUN git clone --branch ${NSIS_BRANCH} --depth=1 git@github.com:NSIS-Dev/nsis.git nsis
+RUN git clone --branch ${NSIS_BRANCH} --depth=1 https://github.com/NSIS-Dev/nsis.git nsis
 
 WORKDIR /build/nsis
 

--- a/packages/nsis/assets/nsis-linux.sh
+++ b/packages/nsis/assets/nsis-linux.sh
@@ -66,11 +66,7 @@ DOCKERFILE="$OUT_DIR/Dockerfile.linux"
 cat > "$DOCKERFILE" <<'DOCKERFILE_END'
 FROM ubuntu:22.04
 
-<<<<<<< nsis-gh-url
 ARG NSIS_BRANCH
-=======
-ARG NSIS_BRANCH=v312
->>>>>>> master
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install build dependencies

--- a/packages/nsis/assets/nsis-mac.sh
+++ b/packages/nsis/assets/nsis-mac.sh
@@ -83,7 +83,7 @@ rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"
 
 if ! git clone --branch "$NSIS_BRANCH" --depth=1 \
-    git@github.com:NSIS-Dev/nsis.git "$BUILD_DIR/nsis"; then
+    https://github.com/NSIS-Dev/nsis.git "$BUILD_DIR/nsis"; then
     echo "❌ Failed to clone NSIS repository"
     exit 1
 fi

--- a/packages/nsis/assets/nsis-mac.sh
+++ b/packages/nsis/assets/nsis-mac.sh
@@ -83,7 +83,7 @@ rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"
 
 if ! git clone --branch "$NSIS_BRANCH" --depth=1 \
-    https://github.com/kichik/nsis.git "$BUILD_DIR/nsis"; then
+    git@github.com:NSIS-Dev/nsis.git "$BUILD_DIR/nsis"; then
     echo "❌ Failed to clone NSIS repository"
     exit 1
 fi


### PR DESCRIPTION
The NSIS project repository was transferred from `kichik/nsis` to `NSIS-Dev/nsis`. This updates all references across the build scripts and includes a few robustness fixes found during review.

- **`nsis-combine.sh`**: Update LICENSE download URL to use `NSIS-Dev/nsis` and pin to `$NSIS_BRANCH` instead of `master`. Also: use `mktemp -d` for temp dir (avoids concurrent-run collisions) and `mapfile` array for macOS bundle iteration (avoids word-splitting on paths).
- **`nsis-mac.sh`** / **`nsis-linux.sh`**: Update `git clone` URL to `NSIS-Dev/nsis`. Remove hardcoded `ARG NSIS_BRANCH=v312` default from Dockerfile template so a missing `--build-arg` fails fast.
- **`nsis-lang-fixes/Hungarian.nsh`** / **`Turkish.nsh`**: Replace `#FIXME` placeholder with the correct translated string for `MUI_INNERTEXT_COMPONENTS_DESCRIPTION_INFO` in the `NSIS_CONFIG_COMPONENTPAGE_ALTERNATIVE` branch.