### PR TITLE
fix(dmg): do not delete uuid (used by mac_alias) since it is lazily loaded are a hard req in python 3.14.2

### DIFF
--- a/.changeset/quick-pants-search.md
+++ b/.changeset/quick-pants-search.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": patch
+---
+
+fix: do not delete uuid since it is lazily loaded in python 3.14.2 + mac_alias

--- a/packages/dmg-builder/assets/build-python-runtime.sh
+++ b/packages/dmg-builder/assets/build-python-runtime.sh
@@ -215,7 +215,7 @@ done
 
 for ext in _asyncio _bz2 _codecs_{cn,hk,iso2022,jp,kr,tw} _crypt \
     _curses{,_panel} _{dbm,gdbm} _lzma _multiprocessing _posixshmem \
-    _queue _sqlite3 _tkinter _uuid audioop nis ossaudiodev readline \
+    _queue _sqlite3 _tkinter audioop nis ossaudiodev readline \
     spwd syslog termios xxlimited; do
     echo "Removing extension module: $ext"
     find "$PYTHON_LIB_DIR/lib-dynload" -name "${ext}*.so" -delete 2>/dev/null || true
@@ -447,6 +447,8 @@ run_arch "$DIR_TO_ARCHIVE/python/bin/python3" -c "
 import dmgbuild
 import ds_store
 import mac_alias
+import uuid
+uuid.uuid4()  # exercises _uuid at runtime
 print('✓ dmgbuild dependencies work')
 "
 


### PR DESCRIPTION
mac_alias only imports uuid lazily — inside alias.py's to_bytes() method, not at module level. So import mac_alias succeeds, the validation passes, and the broken bundle gets archived and shipped.

At runtime, when build_dmg() actually calls alias.to_bytes() to set the DMG background image alias, that's the first time import uuid executes — and it fails.

Why it's No module named 'uuid' and not No module named '_uuid':

In Python 3.12/3.13, uuid.py wrapped _uuid in a try/except ImportError and fell back gracefully to pure-Python UUID generation. In Python 3.14.2, that try/except was removed — _uuid is now a hard dependency. When uuid.py's body raises ModuleNotFoundError during initialization, Python marks the module as failed. The next import uuid call sees the failed entry and re-raises as No module named 'uuid' rather than the original No module named '_uuid'.

The fix is in build-python-runtime.sh: remove _uuid from the extension removal list. It was safe to remove in Python 3.11–3.13 (pure Python fallback existed), but Python 3.14 broke that assumption. Add uuid functionality to test_dmgbuild to catch this class of regression: