### PR TITLE
fix(nsis): validate plugin DLL PE headers and add compile smoke test for all 16 built-in plugins

### DIFF
--- a/.changeset/fifty-sites-glow.md
+++ b/.changeset/fifty-sites-glow.md
@@ -1,0 +1,5 @@
+---
+"nsis": patch
+---
+
+fix(nsis): validate plugin DLL PE headers and add compile smoke test for all 16 built-in plugins

--- a/.github/workflows/build-nsis.yaml
+++ b/.github/workflows/build-nsis.yaml
@@ -20,7 +20,7 @@ jobs:
         shell: bash
 
       - name: Build base bundle
-        run: bash ./build.sh windows
+        run: bash ./build.sh --target windows
         shell: bash
         working-directory: ./packages/nsis
 
@@ -54,7 +54,7 @@ jobs:
         shell: bash
 
       - name: Build macOS binary
-        run: bash ./build.sh mac
+        run: bash ./build.sh --target mac
         shell: bash
         working-directory: ./packages/nsis
 
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Build Linux binary
-        run: bash ./build.sh linux
+        run: bash ./build.sh --target linux
         shell: bash
         working-directory: ./packages/nsis
 
@@ -138,6 +138,7 @@ jobs:
     name: Test NSIS Bundle (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     needs: combine-artifacts
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -145,18 +146,28 @@ jobs:
           - platform: Windows (powershell)
             runner: windows-latest
             binary: makensis.ps1
+            platform_slug: windows
+            upload_installer: true
           - platform: Windows (cmd)
             runner: windows-latest
             binary: makensis.cmd
+            platform_slug: ""
+            upload_installer: false
           - platform: Linux
             runner: ubuntu-latest
             binary: makensis
+            platform_slug: linux
+            upload_installer: true
           - platform: macOS (x64)
             runner: macos-15-intel
             binary: makensis
+            platform_slug: macos-x64
+            upload_installer: true
           - platform: macOS (arm64)
             runner: macos-15
             binary: makensis
+            platform_slug: macos-arm64
+            upload_installer: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -167,124 +178,88 @@ jobs:
           name: nsis-bundle
           path: packages/nsis/out
 
-      - name: Find NSIS bundle
+      - name: Extract NSIS bundle
         shell: bash
         run: |
           BUNDLE_PATH="./packages/nsis/out/nsis"
-          echo "Listing bundle folder:"
-          ls -lhR "$BUNDLE_PATH"
-
-          # Determine extraction target
-          NSIS_BUNDLE="$BUNDLE_PATH/nsis-bundle"
-          mkdir -p "$NSIS_BUNDLE"
-
-          # Convert path for Windows runners
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            # Use cygpath for reliable path conversion
-            WIN_NSIS_BUNDLE=$(cygpath -w "$NSIS_BUNDLE")
-            echo "NSIS_BUNDLE=$WIN_NSIS_BUNDLE" >> $GITHUB_ENV
-          else
-            echo "NSIS_BUNDLE=$NSIS_BUNDLE" >> $GITHUB_ENV
-          fi
-
-          # Enable nullglob for pattern matching
           shopt -s nullglob || true
-
-          # Find the archive
           archives=( "$BUNDLE_PATH"/*.tar.gz )
           if (( ${#archives[@]} == 0 )); then
               echo "ERROR: no *.tar.gz files found in $BUNDLE_PATH"
               exit 1
           fi
-
           echo "Using archive: ${archives[0]}"
-
-          # Extract into NSIS_BUNDLE folder explicitly
           tar -xzf "${archives[0]}" -C "$BUNDLE_PATH"
+          echo "✅ Extracted to $BUNDLE_PATH/nsis-bundle"
 
-          # Verify contents
-          echo "Listing extracted files:"
-          ls -lh "$NSIS_BUNDLE"
-          ls -lh "$NSIS_BUNDLE"/windows
-
-          # Final sanity check
-          if [ ! -d "$NSIS_BUNDLE" ]; then
-            echo "❌ NSIS bundle directory not found after extraction!"
-            exit 1
-          fi
-
-          echo "✅ NSIS bundle ready at $NSIS_BUNDLE"
-
-      - name: Create test NSIS script
+      - name: Run NSIS test suite
+        timeout-minutes: 10
         shell: bash
         run: |
-          cat > test.nsi << 'EOF'
-          !include "MUI2.nsh"
+          bash packages/nsis/assets/nsis-test.sh --bundle-dir packages/nsis/out/nsis/nsis-bundle
 
-          Name "Test Installer"
-          OutFile "test-installer.exe"
-          InstallDir "$PROGRAMFILES\TestApp"
+      - name: Compile E2E installer
+        if: matrix.upload_installer == true
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          WRAPPER="$(pwd)/packages/nsis/out/nsis/nsis-bundle/makensis"
+          chmod +x "$WRAPPER" 2>/dev/null || true
+          # Use RUNNER_TEMP so upload-artifact (Node.js) resolves the path on all platforms
+          E2E_DIR="$RUNNER_TEMP/nsis-e2e"
+          mkdir -p "$E2E_DIR"
 
-          !insertmacro MUI_PAGE_WELCOME
-          !insertmacro MUI_PAGE_DIRECTORY
-          !insertmacro MUI_PAGE_INSTFILES
-          !insertmacro MUI_PAGE_FINISH
+          cat > "$E2E_DIR/e2e.nsi" << 'NSI'
+          Name "NSIS E2E Test"
+          OutFile "e2e-installer.exe"
+          InstallDir "$TEMP\NsisE2ETest"
+          SilentInstall silent
 
-          !insertmacro MUI_LANGUAGE "English"
-
-          Section "Main"
+          Section "Install"
             SetOutPath "$INSTDIR"
+            FileOpen $0 "$INSTDIR\INSTALLED.txt" w
+            FileWrite $0 "nsis-e2e-installed"
+            FileClose $0
             WriteUninstaller "$INSTDIR\Uninstall.exe"
           SectionEnd
 
           Section "Uninstall"
+            Delete "$INSTDIR\INSTALLED.txt"
             Delete "$INSTDIR\Uninstall.exe"
             RMDir "$INSTDIR"
           SectionEnd
-          EOF
+          NSI
 
-      # Step: Test makensis binary (PowerShell on Windows)
-      - name: Test makensis (PowerShell)
-        if: runner.os == 'Windows' && endsWith(matrix.binary, '.ps1')
-        shell: pwsh
-        run: |
-          $BINARY_PATH = Join-Path (Join-Path $env:GITHUB_WORKSPACE "${{ env.NSIS_BUNDLE }}") "${{ matrix.binary }}"
-          if (-not (Test-Path $BINARY_PATH)) {
-              Write-Host "❌ makensis.exe not found!"
-              exit 1
-          }
-          Unblock-File "$BINARY_PATH"
-          & "$BINARY_PATH" -VERSION
-          & "$BINARY_PATH" "test.nsi"
+          cd "$E2E_DIR"
+          bash "$WRAPPER" e2e.nsi
+          echo "✅ E2E installer compiled (${{ matrix.platform_slug }})"
 
-      # Step: Test makensis binary (CMD on Windows)
-      - name: Test makensis (CMD)
-        if: runner.os == 'Windows' && endsWith(matrix.binary, '.cmd')
-        shell: cmd
-        run: |
-          set "BINARY_PATH=%GITHUB_WORKSPACE%\${{ env.NSIS_BUNDLE }}\${{ matrix.binary }}"
-          if not exist "%BINARY_PATH%" (
-              echo ERROR: Binary not found: %BINARY_PATH%
-              exit /b 1
-          )
-          "%BINARY_PATH%" test.nsi
+      - name: Upload E2E installer
+        if: matrix.upload_installer == true
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: nsis-e2e-installer-${{ matrix.platform_slug }}
+          path: ${{ runner.temp }}/nsis-e2e/e2e-installer.exe
+          if-no-files-found: error
+          retention-days: 1
 
-      # Step: Test makensis binary (Linux/macOS)
-      - name: Test makensis (Unix)
-        if: runner.os != 'Windows'
+  test-e2e-install:
+    name: E2E Install + Uninstall (Windows)
+    runs-on: windows-latest
+    needs: test-nsis
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Download all E2E installers
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          pattern: nsis-e2e-installer-*
+          path: installers
+          merge-multiple: false
+
+      - name: Run install + uninstall for each compiled installer
+        timeout-minutes: 10
         shell: bash
-        run: |
-          BINARY_PATH="${{ env.NSIS_BUNDLE }}/${{ matrix.binary }}"
-          "$BINARY_PATH" -VERSION
-          "$BINARY_PATH" test.nsi
-
-      - name: Verify output installer
-        shell: bash
-        run: |
-          ls -l
-          if [[ -f test-installer.exe ]]; then
-              echo "Found installer"
-          else
-              echo "❌ Test compilation failed – no output file"
-              exit 1
-          fi
+        run: bash packages/nsis/assets/nsis-e2e-install.sh --installers-dir installers

--- a/.github/workflows/build-nsis.yaml
+++ b/.github/workflows/build-nsis.yaml
@@ -145,27 +145,22 @@ jobs:
         include:
           - platform: Windows (powershell)
             runner: windows-latest
-            binary: makensis.ps1
             platform_slug: windows
             upload_installer: true
           - platform: Windows (cmd)
             runner: windows-latest
-            binary: makensis.cmd
             platform_slug: ""
             upload_installer: false
           - platform: Linux
             runner: ubuntu-latest
-            binary: makensis
             platform_slug: linux
             upload_installer: true
           - platform: macOS (x64)
             runner: macos-15-intel
-            binary: makensis
             platform_slug: macos-x64
             upload_installer: true
           - platform: macOS (arm64)
             runner: macos-15
-            binary: makensis
             platform_slug: macos-arm64
             upload_installer: true
     steps:

--- a/packages/nsis/assets/nsis-combine.sh
+++ b/packages/nsis/assets/nsis-combine.sh
@@ -43,12 +43,6 @@ MAC_BUNDLES=()
 while IFS= read -r _line; do
     [[ -n "$_line" ]] && MAC_BUNDLES+=("$_line")
 done < <(find "$OUT_DIR" -name "nsis-bundle-mac-*.tar.gz" -type f)
-# Debug output
-echo "Searching in: $OUT_DIR"
-echo "Files found:"
-find "$OUT_DIR" -name "*.tar.gz" -type f 2>/dev/null || echo "  (none)"
-echo ""
-
 # Validate base bundle
 if [ -z "$BASE_BUNDLE" ] || [ ! -f "$BASE_BUNDLE" ]; then
     echo "❌ Base bundle not found in $OUT_DIR"
@@ -140,6 +134,18 @@ if [ "${#MAC_BUNDLES[@]}" -gt 0 ]; then
         
         rm -rf "$TEMP_MAC" "$mac_bundle"
     done
+
+    # Create legacy-compat flat mac/makensis — copies the first available arch binary.
+    # Consumers using the old path (mac/makensis) continue to work alongside the
+    # arch-specific paths (mac/x64/makensis, mac/arm64/makensis).
+    FIRST_MAC_BIN=$(find "$BUILD_DIR/nsis-bundle/mac" -name "makensis" \
+        ! -path "$BUILD_DIR/nsis-bundle/mac/makensis" -type f | head -1)
+    if [ -n "$FIRST_MAC_BIN" ]; then
+        cp "$FIRST_MAC_BIN" "$BUILD_DIR/nsis-bundle/mac/makensis"
+        chmod +x "$BUILD_DIR/nsis-bundle/mac/makensis"
+        FLAT_ARCH=$(basename "$(dirname "$FIRST_MAC_BIN")")
+        echo "  ✓ Legacy mac/makensis created (→ $FLAT_ARCH)"
+    fi
 fi
 
 # =============================================================================
@@ -169,21 +175,37 @@ case "$UNAME_M" in
 esac
 
 # ----------------------------------------
-# macOS / Linux
+# Platform dispatch
 # ----------------------------------------
+NSISDIR_WIN=""
+
 case "$UNAME_S" in
   Darwin)
-    PLATFORM_DIR="mac"
     case "$ARCH" in
       x86_64) ARCH_DIR="x64" ;;
       arm64)  ARCH_DIR="arm64" ;;
       *)      ARCH_DIR="$ARCH" ;;
     esac
-    BINARY="$SCRIPT_DIR/$PLATFORM_DIR/$ARCH_DIR/makensis"
+    BINARY="$SCRIPT_DIR/mac/$ARCH_DIR/makensis"
     ;;
   Linux)
-    PLATFORM_DIR="linux"
-    BINARY="$SCRIPT_DIR/$PLATFORM_DIR/makensis"
+    BINARY="$SCRIPT_DIR/linux/makensis"
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    # makensisw.exe is GUI-subsystem. -VERSION triggers a MessageBox (hangs in
+    # headless CI). Read the version from the bundle's VERSION.txt instead.
+    # All other invocations (compilation) delegate to makensis.cmd via cmd.exe
+    # to avoid MSYS2 path-translation mangling of .nsi file arguments.
+    case "${1:-}" in
+      -VERSION|-version|/VERSION|/version)
+        ver=$(grep -oE "[0-9]+\.[0-9]+" "$SCRIPT_DIR/VERSION.txt" 2>/dev/null | head -1)
+        echo "v${ver:-unknown}"
+        exit 0
+        ;;
+    esac
+    CMD_WIN=$(cygpath -w "$SCRIPT_DIR/makensis.cmd" 2>/dev/null || echo "$SCRIPT_DIR\\makensis.cmd")
+    cmd.exe //c "$CMD_WIN" "$@"
+    exit $?
     ;;
   *)
     echo "❌ Unsupported platform: $UNAME_S" >&2
@@ -200,10 +222,14 @@ if [ ! -f "$BINARY" ]; then
 fi
 
 if [ ! -x "$BINARY" ]; then
-  chmod +x "$BINARY"
+  chmod +x "$BINARY" 2>/dev/null || true
 fi
 
-export NSISDIR="$SCRIPT_DIR/windows"
+if [ -n "$NSISDIR_WIN" ]; then
+  export NSISDIR="$NSISDIR_WIN"
+else
+  export NSISDIR="$SCRIPT_DIR/windows"
+fi
 
 exec "$BINARY" "$@"
 
@@ -227,24 +253,15 @@ setlocal ENABLEEXTENSIONS
 REM =============================================================
 REM NSIS Windows CMD Entrypoint
 REM =============================================================
-REM Sets NSISDIR and forwards all arguments to makensis.exe
+REM Delegates to makensis.ps1 via pwsh so that makensisw.exe
+REM (GUI subsystem) can be run hidden and auto-closed after compile.
 REM =============================================================
 
-REM Determine directory of this script
 set SCRIPT_DIR=%~dp0
-REM Remove trailing backslash
 set SCRIPT_DIR=%SCRIPT_DIR:~0,-1%
 
-REM Set NSISDIR if not already defined
-if not defined NSISDIR (
-  set NSISDIR=%SCRIPT_DIR%\windows
-)
-
-REM Execute makensis.exe with all passed arguments
-"%NSISDIR%\makensis.exe" %*
-set EXITCODE=%ERRORLEVEL%
-
-endlocal & exit /b %EXITCODE%
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%\makensis.ps1" %*
+exit /b %ERRORLEVEL%
 EOF
 
 # Force CRLF line endings for CMD (always)
@@ -261,28 +278,22 @@ echo ""
 echo "🪟 Creating Windows PowerShell entrypoint..."
 
 cat > "$BUILD_DIR/nsis-bundle/makensis.ps1" <<'EOF'
-# =============================================================
-# NSIS Windows PowerShell Entrypoint (CI-safe)
-# =============================================================
-
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
-# Ensure Windows-style paths
+# Normalise MSYS2/Git Bash /c/... style paths to Windows C:\... style
 if ($ScriptDir -notmatch '^[a-zA-Z]:[\\/]' -and $ScriptDir -match '^/([a-zA-Z])/(.*)') {
     $ScriptDir = "$($matches[1]):\$($matches[2] -replace '/', '\')"
 }
 
 $env:NSISDIR = Join-Path $ScriptDir "windows"
-$Makensis   = Join-Path $env:NSISDIR "makensis.exe"
+
+$Makensis = Join-Path $env:NSISDIR "makensis.exe"
 if (-not (Test-Path $Makensis)) {
     Write-Error "makensis.exe not found at: $Makensis"
     exit 1
 }
 
-Unblock-File $Makensis
-& "$Makensis" @args
-
-# Exit with same code
+& $Makensis @args
 exit $LASTEXITCODE
 EOF
 
@@ -350,16 +361,18 @@ export NSISDIR="\$(pwd)/windows"
 
 ## Included Plugins
 
-This bundle includes 8 additional community plugins:
+This bundle includes 10 additional community plugins:
 
-1. NsProcess - Process management
-2. UAC - User Account Control
-3. WinShell - Shell integration
-4. NsJSON - JSON parsing
-5. NsArray - Array support
-6. INetC - HTTP client
-7. NsisMultiUser - Multi-user installs
-8. StdUtils - Standard utilities
+1. INetC - HTTP/HTTPS download plugin
+2. StdUtils - Standard utilities (strings, math, system)
+3. SpiderBanner - Animated splash/banner
+4. NsProcess - Process management (list, kill)
+5. UAC - User Account Control elevation
+6. WinShell - Shell integration (file associations, shortcuts)
+7. EmbedHTML - Embed HTML pages in installer
+8. Nsisunz - ZIP extraction (ANSI)
+9. NSISunzU - ZIP extraction (Unicode)
+10. nsis7z - 7-Zip extraction
 
 ## Environment Variables
 

--- a/packages/nsis/assets/nsis-combine.sh
+++ b/packages/nsis/assets/nsis-combine.sh
@@ -177,8 +177,6 @@ esac
 # ----------------------------------------
 # Platform dispatch
 # ----------------------------------------
-NSISDIR_WIN=""
-
 case "$UNAME_S" in
   Darwin)
     case "$ARCH" in
@@ -225,11 +223,7 @@ if [ ! -x "$BINARY" ]; then
   chmod +x "$BINARY" 2>/dev/null || true
 fi
 
-if [ -n "$NSISDIR_WIN" ]; then
-  export NSISDIR="$NSISDIR_WIN"
-else
-  export NSISDIR="$SCRIPT_DIR/windows"
-fi
+export NSISDIR="$SCRIPT_DIR/windows"
 
 exec "$BINARY" "$@"
 

--- a/packages/nsis/assets/nsis-e2e-install.sh
+++ b/packages/nsis/assets/nsis-e2e-install.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# NSIS E2E Install + Uninstall Runner
+# =============================================================================
+# Usage: nsis-e2e-install.sh [--installers-dir PATH]
+#
+# --installers-dir PATH  Directory containing nsis-e2e-installer-{platform}/ subdirs,
+#                        each holding an e2e-installer.exe compiled by that platform.
+#                        Defaults to ./installers
+#
+# Runs install + uninstall for every installer found. Exits with the total
+# number of failures (0 = all passed).
+# =============================================================================
+
+INSTALLERS_DIR="./installers"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --installers-dir) INSTALLERS_DIR="${2:-}"; shift 2 ;;
+        *) echo "❌ Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+PASS=0
+FAIL=0
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo "  E2E Install + Uninstall — all compiled platforms"
+echo "  Installers: $INSTALLERS_DIR"
+echo "═══════════════════════════════════════════════════════════════"
+
+for dir in "$INSTALLERS_DIR"/nsis-e2e-installer-*/; do
+    platform="${dir#"$INSTALLERS_DIR"/nsis-e2e-installer-}"
+    platform="${platform%/}"
+    installer="$dir/e2e-installer.exe"
+    install_dir="${TEMP:-/tmp}/NsisE2ETest"
+
+    echo ""
+    echo "── $platform ───────────────────────────────────────────────"
+
+    if [ ! -f "$installer" ]; then
+        echo "[FAIL] $platform: installer not found at $installer"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    # Clean any leftover from a previous loop iteration
+    rm -rf "$install_dir" 2>/dev/null || true
+
+    # Install (SilentInstall silent is set in the NSI; /S is explicit for clarity)
+    if "$installer" /S; then
+        echo "[PASS] $platform: install succeeded"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $platform: installer returned non-zero"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    # Verify sentinel file
+    if [ -f "$install_dir/INSTALLED.txt" ]; then
+        echo "[PASS] $platform: INSTALLED.txt created"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $platform: INSTALLED.txt not found at $install_dir"
+        FAIL=$((FAIL + 1))
+    fi
+
+    # Uninstall
+    UNINSTALLER="$install_dir/Uninstall.exe"
+    if [ -f "$UNINSTALLER" ]; then
+        "$UNINSTALLER" /S || true
+        # NSIS uninstallers copy themselves to TEMP before running; give it a moment to finish
+        sleep 2
+
+        if [ ! -f "$install_dir/INSTALLED.txt" ]; then
+            echo "[PASS] $platform: INSTALLED.txt removed"
+            PASS=$((PASS + 1))
+        else
+            echo "[FAIL] $platform: INSTALLED.txt still present after uninstall"
+            FAIL=$((FAIL + 1))
+        fi
+
+        if [ ! -d "$install_dir" ]; then
+            echo "[PASS] $platform: install directory removed"
+            PASS=$((PASS + 1))
+        else
+            echo "[FAIL] $platform: install directory still present after uninstall"
+            FAIL=$((FAIL + 1))
+            rm -rf "$install_dir" 2>/dev/null || true
+        fi
+    else
+        echo "[FAIL] $platform: Uninstall.exe not found at $install_dir"
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+printf "  Results: %d passed, %d failed\n" "$PASS" "$FAIL"
+echo "═══════════════════════════════════════════════════════════════"
+echo ""
+
+exit $FAIL

--- a/packages/nsis/assets/nsis-e2e-install.sh
+++ b/packages/nsis/assets/nsis-e2e-install.sh
@@ -32,7 +32,14 @@ echo "  E2E Install + Uninstall — all compiled platforms"
 echo "  Installers: $INSTALLERS_DIR"
 echo "═══════════════════════════════════════════════════════════════"
 
-for dir in "$INSTALLERS_DIR"/nsis-e2e-installer-*/; do
+shopt -s nullglob
+dirs=( "$INSTALLERS_DIR"/nsis-e2e-installer-*/ )
+if [[ ${#dirs[@]} -eq 0 ]]; then
+    echo "❌ No installer directories found in $INSTALLERS_DIR"
+    exit 1
+fi
+
+for dir in "${dirs[@]}"; do
     platform="${dir#"$INSTALLERS_DIR"/nsis-e2e-installer-}"
     platform="${platform%/}"
     installer="$dir/e2e-installer.exe"

--- a/packages/nsis/assets/nsis-mac.sh
+++ b/packages/nsis/assets/nsis-mac.sh
@@ -100,7 +100,13 @@ echo "   This may take 5-10 minutes..."
 
 cd "$BUILD_DIR/nsis"
 
+# Detect Homebrew prefix for header/library paths (arm64: /opt/homebrew, x64: /usr/local)
+BREW_PREFIX=$(brew --prefix 2>/dev/null || echo "")
+SCONS_BREW_FLAGS=""
+[ -n "$BREW_PREFIX" ] && SCONS_BREW_FLAGS="APPEND_CPPPATH=$BREW_PREFIX/include APPEND_LIBPATH=$BREW_PREFIX/lib"
+
 # Build with SCons
+# shellcheck disable=SC2086
 if ! scons \
     SKIPSTUBS=all \
     SKIPPLUGINS=all \
@@ -109,6 +115,7 @@ if ! scons \
     NSIS_CONFIG_CONST_DATA_PATH=no \
     NSIS_CONFIG_LOG=yes \
     NSIS_MAX_STRLEN=8192 \
+    $SCONS_BREW_FLAGS \
     PREFIX="$BUILD_DIR/install" \
     install-compiler; then
     echo "❌ Compilation failed"

--- a/packages/nsis/assets/nsis-test.sh
+++ b/packages/nsis/assets/nsis-test.sh
@@ -643,9 +643,20 @@ NSI
                 fail "E2E install: installer returned non-zero"
             fi
 
-            # $TEMP in bash on Windows (Git Bash) maps to the Windows TEMP dir.
-            # NSIS $TEMP macro also expands to the Windows TEMP dir.
-            E2E_INSTALL_DIR="${TEMP:-/tmp}/NsisE2ETest"
+            # Resolve the install directory. NSIS $TEMP expands differently on Wine vs. native.
+            if $IS_WINDOWS; then
+                # Git Bash $TEMP already maps to the Windows TEMP dir.
+                E2E_INSTALL_DIR="${TEMP:-/tmp}/NsisE2ETest"
+            else
+                # Wine: NSIS $TEMP resolves inside the Wine prefix, not the host $TEMP.
+                _wine_temp=$(wine cmd /c 'echo %TEMP%' 2>/dev/null | tr -d '\r\n')
+                if command -v winepath &>/dev/null && [ -n "$_wine_temp" ]; then
+                    E2E_INSTALL_DIR=$(winepath -u "${_wine_temp}\\NsisE2ETest" 2>/dev/null \
+                        || echo "${HOME}/.wine/drive_c/users/$(id -un)/Temp/NsisE2ETest")
+                else
+                    E2E_INSTALL_DIR="${HOME}/.wine/drive_c/users/$(id -un)/Temp/NsisE2ETest"
+                fi
+            fi
 
             if [ -f "$E2E_INSTALL_DIR/INSTALLED.txt" ]; then
                 pass "E2E install: INSTALLED.txt created"

--- a/packages/nsis/assets/nsis-test.sh
+++ b/packages/nsis/assets/nsis-test.sh
@@ -1,0 +1,697 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# NSIS Bundle Test Suite
+# =============================================================================
+# Usage: nsis-test.sh [--bundle-dir PATH] [--full]
+#
+# --bundle-dir PATH  Path to extracted nsis-bundle directory.
+#                    Defaults to ./out/nsis/nsis-bundle relative to this script.
+#
+# --full             Enable the optional end-to-end install + uninstall test (Test 15).
+#                    Requires Windows or Linux+Wine to execute the installer.
+#
+# Exit code 0 = all non-skipped tests passed.
+# =============================================================================
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+BUNDLE_DIR="$SCRIPT_DIR/../out/nsis/nsis-bundle"
+FULL_TEST=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bundle-dir) BUNDLE_DIR="${2:-}"; shift 2 ;;
+        --full)       FULL_TEST="--full"; shift ;;
+        *) echo "❌ Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+BUNDLE_DIR=$(cd "$BUNDLE_DIR" && pwd)
+
+PASS=0
+FAIL=0
+SKIP=0
+TMPDIR_TEST=$(mktemp -d)
+
+cleanup() { rm -rf "$TMPDIR_TEST"; }
+trap cleanup EXIT INT TERM
+
+# =============================================================================
+# OS + arch detection
+# =============================================================================
+
+IS_WINDOWS=false
+IS_MAC=false
+IS_LINUX=false
+case "$(uname -s)" in
+    Darwin*)              IS_MAC=true ;;
+    Linux*)               IS_LINUX=true ;;
+    MINGW*|MSYS*|CYGWIN*) IS_WINDOWS=true ;;
+esac
+[ "${OS:-}" = "Windows_NT" ] && IS_WINDOWS=true
+
+ARCH=$(uname -m 2>/dev/null || echo "unknown")
+case "$ARCH" in
+    x86_64|amd64)  MAC_ARCH_DIR="x64" ;;
+    arm64|aarch64) MAC_ARCH_DIR="arm64" ;;
+    *)             MAC_ARCH_DIR="$ARCH" ;;
+esac
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+pass()  { echo "[PASS] $*"; PASS=$((PASS + 1)); }
+fail()  { echo "[FAIL] $*"; FAIL=$((FAIL + 1)); }
+skip()  { echo "[SKIP] $*"; SKIP=$((SKIP + 1)); }
+
+assert_dir()  { [ -d "$1" ] && pass "$2" || fail "$2 (missing dir: $1)"; }
+assert_file() { [ -f "$1" ] && pass "$2" || fail "$2 (missing file: $1)"; }
+
+assert_patch() {
+    local file="$1" label="$2"
+    if grep -q "BEGIN FIXES ADDED" "$file" 2>/dev/null; then
+        pass "$label: language patch applied"
+    else
+        fail "$label: language patch marker missing (fixes not applied)"
+    fi
+}
+
+# Run the makensis bash wrapper (handles executable bit or bash fallback)
+run_wrapper() {
+    local bin="$1"; shift
+    if [ -x "$bin" ]; then "$bin" "$@"; else bash "$bin" "$@"; fi
+}
+
+# =============================================================================
+# Header
+# =============================================================================
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo "  NSIS Bundle Test Suite"
+echo "═══════════════════════════════════════════════════════════════"
+echo "  Bundle:   $BUNDLE_DIR"
+echo "  OS:       $(uname -s) / $ARCH"
+E2E_STATUS="disabled (pass --full to enable)"
+[ -n "$FULL_TEST" ] && E2E_STATUS="enabled (--full)"
+echo "  Full E2E: $E2E_STATUS"
+echo "═══════════════════════════════════════════════════════════════"
+echo ""
+
+# =============================================================================
+# TEST 1 — Bundle structure
+# =============================================================================
+
+echo "── Test 1: Bundle structure ────────────────────────────────────"
+
+assert_dir  "$BUNDLE_DIR/windows"      "windows/ present"
+assert_dir  "$BUNDLE_DIR/linux"        "linux/ present"
+assert_dir  "$BUNDLE_DIR/mac"          "mac/ present"
+assert_file "$BUNDLE_DIR/makensis"     "makensis wrapper present"
+assert_file "$BUNDLE_DIR/makensis.cmd" "makensis.cmd present"
+assert_file "$BUNDLE_DIR/makensis.ps1" "makensis.ps1 present"
+
+# =============================================================================
+# TEST 2 — Binary presence
+# Platform-specific arch binaries are required when running on that platform.
+# =============================================================================
+
+echo ""
+echo "── Test 2: Binary presence ─────────────────────────────────────"
+
+assert_file "$BUNDLE_DIR/windows/makensisw.exe"         "windows/makensisw.exe present"
+assert_file "$BUNDLE_DIR/windows/makensis.exe"          "windows/makensis.exe (console stub) present"
+assert_file "$BUNDLE_DIR/windows/Bin/makensis.exe"      "windows/Bin/makensis.exe (strlen-patched) present"
+assert_file "$BUNDLE_DIR/linux/makensis"                "linux/makensis present"
+assert_file "$BUNDLE_DIR/mac/makensis"             "mac/makensis (legacy flat) present"
+
+if $IS_MAC; then
+    # Current arch is required; opposite arch is opportunistic
+    assert_file "$BUNDLE_DIR/mac/$MAC_ARCH_DIR/makensis" "mac/$MAC_ARCH_DIR/makensis present"
+    OTHER_ARCH="arm64"; [ "$MAC_ARCH_DIR" = "arm64" ] && OTHER_ARCH="x64"
+    if [ -f "$BUNDLE_DIR/mac/$OTHER_ARCH/makensis" ]; then
+        pass "mac/$OTHER_ARCH/makensis present (multi-arch build)"
+    else
+        skip "mac/$OTHER_ARCH/makensis absent (single-arch build)"
+    fi
+fi
+
+# =============================================================================
+# TEST 3 — Binary format
+# Required on the native OS; no skipping.
+# =============================================================================
+
+echo ""
+echo "── Test 3: Binary format ───────────────────────────────────────"
+
+if $IS_LINUX; then
+    if command -v file &>/dev/null; then
+        FILE_OUT=$(file "$BUNDLE_DIR/linux/makensis")
+        if echo "$FILE_OUT" | grep -q "ELF"; then
+            pass "linux/makensis: valid ELF binary"
+        else
+            fail "linux/makensis: not ELF (got: $FILE_OUT)"
+        fi
+    else
+        # od fallback: ELF magic = 7f 45 4c 46
+        ELF_MAGIC=$(od -N 4 -A n -t x1 "$BUNDLE_DIR/linux/makensis" 2>/dev/null | tr -d ' \n')
+        if [ "$ELF_MAGIC" = "7f454c46" ]; then
+            pass "linux/makensis: valid ELF binary (magic bytes)"
+        else
+            fail "linux/makensis: ELF magic check failed (got: '$ELF_MAGIC')"
+        fi
+    fi
+fi
+
+if $IS_MAC; then
+    MAC_BIN="$BUNDLE_DIR/mac/$MAC_ARCH_DIR/makensis"
+    [ -f "$MAC_BIN" ] || MAC_BIN="$BUNDLE_DIR/mac/makensis"
+    if command -v file &>/dev/null; then
+        FILE_OUT=$(file "$MAC_BIN")
+        if echo "$FILE_OUT" | grep -q "Mach-O"; then
+            pass "mac/$MAC_ARCH_DIR/makensis: valid Mach-O binary"
+        else
+            fail "mac/$MAC_ARCH_DIR/makensis: not Mach-O (got: $FILE_OUT)"
+        fi
+    else
+        # od fallback: Mach-O magics (little-endian 32/64bit or fat binary)
+        MAC_MAGIC=$(od -N 4 -A n -t x1 "$MAC_BIN" 2>/dev/null | tr -d ' \n')
+        if echo "$MAC_MAGIC" | grep -qE "^(cefaedfe|cffaedfe|cafebabe)"; then
+            pass "mac/$MAC_ARCH_DIR/makensis: valid Mach-O binary (magic bytes)"
+        else
+            fail "mac/$MAC_ARCH_DIR/makensis: Mach-O magic check failed (got: '$MAC_MAGIC')"
+        fi
+    fi
+fi
+
+if $IS_WINDOWS; then
+    # PE magic = MZ = 4d 5a — check the actual compiler (makensisw.exe)
+    _bin_path="$BUNDLE_DIR/windows/makensisw.exe"
+    MZ=$(od -N 2 -A n -t x1 "$_bin_path" 2>/dev/null | tr -d ' \n')
+    if [ "$MZ" = "4d5a" ]; then
+        pass "windows/makensisw.exe: valid PE binary (MZ header)"
+    elif command -v pwsh &>/dev/null; then
+        WIN_MKS=$(cygpath -w "$_bin_path" 2>/dev/null || echo "$_bin_path")
+        MZ_PS=$(pwsh -NoProfile -Command \
+            "[System.IO.File]::ReadAllBytes('$WIN_MKS')[0] -eq 77" 2>/dev/null | tr -d '\r')
+        if [ "$MZ_PS" = "True" ]; then
+            pass "windows/makensisw.exe: valid PE binary (MZ header via PowerShell)"
+        else
+            fail "windows/makensisw.exe: MZ header check failed"
+        fi
+    else
+        fail "windows/makensisw.exe: cannot verify PE header (od and pwsh both unavailable)"
+    fi
+fi
+
+# =============================================================================
+# TEST 4 — NSISDIR data files
+# =============================================================================
+
+echo ""
+echo "── Test 4: NSISDIR data files ──────────────────────────────────"
+
+assert_dir  "$BUNDLE_DIR/windows/Bin"                 "windows/Bin present"
+assert_dir  "$BUNDLE_DIR/windows/Contrib"             "windows/Contrib present"
+assert_dir  "$BUNDLE_DIR/windows/Include"             "windows/Include present"
+assert_dir  "$BUNDLE_DIR/windows/Plugins"             "windows/Plugins present"
+assert_dir  "$BUNDLE_DIR/windows/Stubs"               "windows/Stubs present"
+assert_dir  "$BUNDLE_DIR/windows/Plugins/x86-ansi"    "Plugins/x86-ansi present"
+assert_dir  "$BUNDLE_DIR/windows/Plugins/x86-unicode" "Plugins/x86-unicode present"
+assert_file "$BUNDLE_DIR/windows/makensisw.exe"       "windows/makensisw.exe present"
+assert_file "$BUNDLE_DIR/windows/nsisconf.nsh"        "windows/nsisconf.nsh present"
+
+# =============================================================================
+# TEST 5 — Language files: assert every file by name + verify patches
+# =============================================================================
+
+echo ""
+echo "── Test 5: Language files ──────────────────────────────────────"
+
+LANG_DIR="$BUNDLE_DIR/windows/Contrib/Language files"
+assert_dir "$LANG_DIR" "Contrib/Language files/ present"
+
+LANG_NAMES=(
+    Afrikaans Albanian Arabic Armenian Asturian Basque Belarusian Bosnian Breton
+    Bulgarian Catalan Corsican Croatian Czech Danish Dutch English
+    Esperanto Estonian Farsi Finnish French Galician Georgian German Greek Hebrew
+    Hindi Hungarian Icelandic Indonesian Irish Italian Japanese Korean
+    Kurdish Latvian Lithuanian Luxembourgish Macedonian Malay Mongolian
+    Norwegian NorwegianNynorsk Pashto Polish Portuguese PortugueseBR Romanian
+    Russian ScotsGaelic Serbian SerbianLatin SimpChinese Slovak Slovenian Spanish
+    SpanishInternational Swedish Tatar Thai TradChinese Turkish Ukrainian
+    Uzbek Vietnamese Welsh
+)
+
+for lang in "${LANG_NAMES[@]}"; do
+    assert_file "$LANG_DIR/${lang}.nlf" "${lang}.nlf present"
+    assert_file "$LANG_DIR/${lang}.nsh" "${lang}.nsh present"
+done
+
+# Verify patch markers for the 5 .nsh-patched languages
+for lang in Finnish Hungarian Korean Thai Turkish; do
+    [ -f "$LANG_DIR/${lang}.nsh" ] && assert_patch "$LANG_DIR/${lang}.nsh" "${lang}.nsh"
+done
+
+# Verify patch marker for the 1 .nlf-patched language
+[ -f "$LANG_DIR/SimpChinese.nlf" ] && assert_patch "$LANG_DIR/SimpChinese.nlf" "SimpChinese.nlf"
+
+# =============================================================================
+# TEST 6 — Plugin DLLs: assert every base DLL by name in both archs
+# =============================================================================
+
+echo ""
+echo "── Test 6: Plugin DLLs ─────────────────────────────────────────"
+
+BASE_DLLS=(
+    AdvSplash.dll
+    Banner.dll
+    BgImage.dll
+    Dialer.dll
+    InstallOptions.dll
+    LangDLL.dll
+    Math.dll
+    NSISdl.dll
+    Splash.dll
+    StartMenu.dll
+    System.dll
+    TypeLib.dll
+    UserInfo.dll
+    VPatch.dll
+    nsDialogs.dll
+    nsExec.dll
+)
+
+for arch_dir in x86-unicode x86-ansi; do
+    for dll in "${BASE_DLLS[@]}"; do
+        assert_file "$BUNDLE_DIR/windows/Plugins/$arch_dir/$dll" \
+            "Plugins/$arch_dir/$dll present"
+    done
+done
+
+# Validate each DLL is a genuine Windows PE (MZ magic bytes)
+for arch_dir in x86-unicode x86-ansi; do
+    for dll in "${BASE_DLLS[@]}"; do
+        dll_path="$BUNDLE_DIR/windows/Plugins/$arch_dir/$dll"
+        if [ -f "$dll_path" ]; then
+            MZ_DLL=$(od -N 2 -A n -t x1 "$dll_path" 2>/dev/null | tr -d ' \n')
+            if [ "$MZ_DLL" = "4d5a" ]; then
+                pass "Plugins/$arch_dir/$dll valid MZ header"
+            else
+                fail "Plugins/$arch_dir/$dll invalid or missing MZ header"
+            fi
+        else
+            skip "Plugins/$arch_dir/$dll not found (existence checked above)"
+        fi
+    done
+done
+
+# =============================================================================
+# Set up the wrapper for compile tests 7-15
+# =============================================================================
+
+WRAPPER="$BUNDLE_DIR/makensis"
+chmod +x "$WRAPPER" 2>/dev/null || true
+
+# =============================================================================
+# TEST 7 — Version flag
+# =============================================================================
+
+echo ""
+echo "── Test 7: Version flag ────────────────────────────────────────"
+
+if VERSION_OUT=$(run_wrapper "$WRAPPER" -VERSION 2>&1); then
+    # Accept release tags (v3.12) and CVS date strings from source builds (20-May-2026.cvs)
+    if echo "$VERSION_OUT" | grep -qiE "v?3\.[0-9]|[0-9]+-[A-Za-z]+-[0-9]{4}"; then
+        pass "Version flag: $(echo "$VERSION_OUT" | tr -d '\r\n')"
+    else
+        fail "Version flag: unexpected output: $VERSION_OUT"
+    fi
+else
+    fail "Version flag: wrapper exited non-zero (output: $(echo "$VERSION_OUT" | tr -d '\r\n'))"
+fi
+
+# =============================================================================
+# TEST 8 — Minimal compile
+# =============================================================================
+
+echo ""
+echo "── Test 8: Minimal compile ─────────────────────────────────────"
+
+cat > "$TMPDIR_TEST/minimal.nsi" <<'NSI'
+Name "Minimal"
+OutFile "minimal.exe"
+InstallDir "$TEMP\MinimalTest"
+Section
+SectionEnd
+NSI
+
+cd "$TMPDIR_TEST"
+echo "  [cmd] $WRAPPER minimal.nsi"
+_t8_start=$(date +%s 2>/dev/null || echo 0)
+# Run without output capture so PS1 Write-Output lines appear live in CI logs
+if run_wrapper "$WRAPPER" "minimal.nsi"; then
+    _t8_rc=0
+else
+    _t8_rc=$?
+fi
+_t8_end=$(date +%s 2>/dev/null || echo 0)
+echo "  [rc]  $_t8_rc  elapsed: $(( _t8_end - _t8_start ))s"
+if [ $_t8_rc -eq 0 ] && [ -f "minimal.exe" ]; then
+    pass "Minimal compile: minimal.exe produced"
+else
+    echo "  [exe] $([ -f minimal.exe ] && echo present || echo MISSING)"
+    fail "Minimal compile: exit=$_t8_rc"
+fi
+
+# =============================================================================
+# TEST 9 — MUI2 compile (exercises Include/ + Contrib/ resolution via NSISDIR)
+# =============================================================================
+
+echo ""
+echo "── Test 9: MUI2 compile ────────────────────────────────────────"
+
+cat > "$TMPDIR_TEST/mui2.nsi" <<'NSI'
+!include "MUI2.nsh"
+
+Name "MUI2 Test"
+OutFile "mui2-installer.exe"
+InstallDir "$TEMP\MUI2Test"
+
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_LANGUAGE "English"
+
+Section "Main"
+  SetOutPath "$INSTDIR"
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+SectionEnd
+
+Section "Uninstall"
+  Delete "$INSTDIR\Uninstall.exe"
+  RMDir "$INSTDIR"
+SectionEnd
+NSI
+
+cd "$TMPDIR_TEST"
+if run_wrapper "$WRAPPER" "mui2.nsi" >/dev/null 2>&1 && [ -f "mui2-installer.exe" ]; then
+    pass "MUI2 compile: mui2-installer.exe produced"
+else
+    fail "MUI2 compile: failed (NSISDIR or Include resolution failure)"
+fi
+
+# =============================================================================
+# TEST 10 — strlen_8192 patch verification
+# =============================================================================
+
+echo ""
+echo "── Test 10: strlen_8192 ────────────────────────────────────────"
+
+LONG_STR=$(printf 'A%.0s' {1..8000})
+
+cat > "$TMPDIR_TEST/strlen.nsi" <<NSI
+Name "StrLen Test"
+OutFile "strlen-test.exe"
+InstallDir "\$TEMP\StrLenTest"
+
+!define LONG_STRING "$LONG_STR"
+
+Section
+  DetailPrint "\${LONG_STRING}"
+SectionEnd
+NSI
+
+cd "$TMPDIR_TEST"
+STRLEN_OUT=$(run_wrapper "$WRAPPER" "strlen.nsi" 2>&1 || true)
+if echo "$STRLEN_OUT" | grep -qi "string too long\|overflow"; then
+    fail "strlen_8192: string overflow error (patch not applied)"
+elif [ -f "strlen-test.exe" ]; then
+    pass "strlen_8192: 8000-char string compiled without overflow"
+else
+    fail "strlen_8192: compile failed: $STRLEN_OUT"
+fi
+
+# =============================================================================
+# TEST 11 — Plugin DLL compile smoke test
+# =============================================================================
+
+echo ""
+echo "── Test 11: Plugin DLL compile smoke test ──────────────────────"
+
+cat > "$TMPDIR_TEST/plugin-smoke.nsi" <<'NSI'
+Name "Plugin DLL Smoke Test"
+OutFile "plugin-smoke.exe"
+InstallDir "$TEMP\NSISPluginSmokeTest"
+SilentInstall silent
+
+; Each Plugin::Function call causes makensis to locate the DLL,
+; read its PE export table, and embed it. Installer is never executed.
+Section "Main"
+  nsExec::Exec 'echo test'
+  Pop $0
+  Math::Script 'var x=1;'
+  System::Call 'kernel32::GetTickCount()i'
+  Pop $0
+  UserInfo::GetAccountType
+  Pop $0
+  StartMenu::Select /autoadd /noicon "$SMPROGRAMS\Test" "Test"
+  Pop $0
+  TypeLib::Register "$SYSDIR\stdole2.tlb"
+  Pop $0
+  VPatch::GetFileCRC32 "$EXEPATH" $0
+  AdvSplash::show /NOUNLOAD 1000 1000 0 "$PLUGINSDIR\splash" "" ""
+  Banner::show /NOUNLOAD /set 76 "Smoke Test" "Testing..."
+  Banner::destroy
+  BgImage::Destroy /RESET
+  Splash::show /NOUNLOAD 1000 "$PLUGINSDIR\splash" "none"
+  nsDialogs::Create 1018
+  Pop $0
+  InstallOptions::dialog "$PLUGINSDIR\test.ini"
+  LangDLL::LangDialog "Smoke Test" "" "English" "English"
+  Dialer::AttemptConnect
+  NSISdl::download "http://localhost" "$TEMP\noop.tmp"
+SectionEnd
+NSI
+
+cd "$TMPDIR_TEST"
+SMOKE_OUT=$(run_wrapper "$WRAPPER" "plugin-smoke.nsi" 2>&1 || true)
+if [ -f "plugin-smoke.exe" ]; then
+    pass "Plugin smoke compile: all 16 plugin DLLs loaded and embedded"
+else
+    fail "Plugin smoke compile: failed — $SMOKE_OUT"
+fi
+
+# =============================================================================
+# TEST 12 — Direct binary + explicit NSISDIR (Linux/macOS only)
+# =============================================================================
+
+echo ""
+echo "── Test 12: Direct binary + explicit NSISDIR ───────────────────"
+
+DIRECT_BIN=""
+if $IS_LINUX && [ -f "$BUNDLE_DIR/linux/makensis" ]; then
+    DIRECT_BIN="$BUNDLE_DIR/linux/makensis"
+    chmod +x "$DIRECT_BIN" 2>/dev/null || true
+elif $IS_MAC; then
+    DIRECT_BIN="$BUNDLE_DIR/mac/$MAC_ARCH_DIR/makensis"
+    [ -f "$DIRECT_BIN" ] || DIRECT_BIN="$BUNDLE_DIR/mac/makensis"
+    chmod +x "$DIRECT_BIN" 2>/dev/null || true
+fi
+
+if [ -n "$DIRECT_BIN" ] && [ -f "$DIRECT_BIN" ]; then
+    cat > "$TMPDIR_TEST/direct.nsi" <<'NSI'
+Name "Direct"
+OutFile "direct-test.exe"
+InstallDir "$TEMP\DirectTest"
+Section
+SectionEnd
+NSI
+    cd "$TMPDIR_TEST"
+    if NSISDIR="$BUNDLE_DIR/windows" "$DIRECT_BIN" "direct.nsi" >/dev/null 2>&1 \
+       && [ -f "direct-test.exe" ]; then
+        pass "Direct binary + NSISDIR: compiled successfully"
+    else
+        fail "Direct binary + NSISDIR: binary returned non-zero or no output"
+    fi
+else
+    skip "Direct binary + NSISDIR: no native binary for this platform (Windows)"
+fi
+
+# =============================================================================
+# TEST 13 — makensis.cmd (Windows only)
+# =============================================================================
+
+echo ""
+echo "── Test 13: makensis.cmd (Windows) ─────────────────────────────"
+
+if $IS_WINDOWS; then
+    cat > "$TMPDIR_TEST/cmd.nsi" <<'NSI'
+Name "CMD"
+OutFile "cmd-test.exe"
+InstallDir "$TEMP\CMDTest"
+Section
+SectionEnd
+NSI
+    cd "$TMPDIR_TEST"
+    CMD_BIN="$BUNDLE_DIR/makensis.cmd"
+    # Run .cmd directly — MSYS2/Git Bash launches it via cmd.exe with path conversion
+    if "$CMD_BIN" "cmd.nsi" >/dev/null 2>&1 && [ -f "cmd-test.exe" ]; then
+        pass "makensis.cmd: compiled successfully"
+    else
+        fail "makensis.cmd: failed"
+    fi
+else
+    skip "makensis.cmd: not Windows"
+fi
+
+# =============================================================================
+# TEST 14 — makensis.ps1 (Windows only)
+# =============================================================================
+
+echo ""
+echo "── Test 14: makensis.ps1 (Windows) ─────────────────────────────"
+
+if $IS_WINDOWS; then
+    cat > "$TMPDIR_TEST/ps1.nsi" <<'NSI'
+Name "PS1"
+OutFile "ps1-test.exe"
+InstallDir "$TEMP\PS1Test"
+Section
+SectionEnd
+NSI
+    cd "$TMPDIR_TEST"
+    PS1_BIN="$BUNDLE_DIR/makensis.ps1"
+    if command -v pwsh &>/dev/null; then
+        if pwsh -ExecutionPolicy Bypass -File "$PS1_BIN" "ps1.nsi" >/dev/null 2>&1 \
+           && [ -f "ps1-test.exe" ]; then
+            pass "makensis.ps1: compiled successfully"
+        else
+            fail "makensis.ps1: failed"
+        fi
+    else
+        skip "makensis.ps1: pwsh not available"
+    fi
+else
+    skip "makensis.ps1: not Windows"
+fi
+
+# =============================================================================
+# TEST 15 — End-to-end install + uninstall  (optional: pass --full)
+# =============================================================================
+
+echo ""
+echo "── Test 15: E2E install + uninstall ────────────────────────────"
+
+if [ "$FULL_TEST" != "--full" ]; then
+    skip "E2E installer: pass --full to enable this test"
+else
+    # Write a self-contained installer:
+    #   - SilentInstall silent  → no UI, no /S flag needed
+    #   - Writes INSTALLED.txt + Uninstall.exe to $TEMP\NsisE2ETest
+    #   - Uninstall section cleans up completely
+    cat > "$TMPDIR_TEST/e2e.nsi" <<'NSI'
+Name "NSIS E2E Test"
+OutFile "e2e-installer.exe"
+InstallDir "$TEMP\NsisE2ETest"
+SilentInstall silent
+
+Section "Install"
+  SetOutPath "$INSTDIR"
+  FileOpen $0 "$INSTDIR\INSTALLED.txt" w
+  FileWrite $0 "nsis-e2e-installed"
+  FileClose $0
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+SectionEnd
+
+Section "Uninstall"
+  Delete "$INSTDIR\INSTALLED.txt"
+  Delete "$INSTDIR\Uninstall.exe"
+  RMDir "$INSTDIR"
+SectionEnd
+NSI
+
+    cd "$TMPDIR_TEST"
+    if run_wrapper "$WRAPPER" "e2e.nsi" >/dev/null 2>&1 && [ -f "e2e-installer.exe" ]; then
+        pass "E2E compile: e2e-installer.exe produced"
+    else
+        fail "E2E compile: failed to produce e2e-installer.exe"
+    fi
+
+    if [ -f "$TMPDIR_TEST/e2e-installer.exe" ]; then
+        # Determine how to execute the installer
+        RUN_CMD=()
+        CAN_RUN=false
+
+        if $IS_WINDOWS; then
+            CAN_RUN=true
+            RUN_CMD=("$TMPDIR_TEST/e2e-installer.exe")
+        elif $IS_LINUX && command -v wine &>/dev/null; then
+            CAN_RUN=true
+            RUN_CMD=(wine "$TMPDIR_TEST/e2e-installer.exe")
+        fi
+
+        if $CAN_RUN; then
+            # Run installer (SilentInstall silent is set in NSI, /S is redundant but explicit)
+            if "${RUN_CMD[@]}" /S >/dev/null 2>&1; then
+                pass "E2E install: installer ran without error"
+            else
+                fail "E2E install: installer returned non-zero"
+            fi
+
+            # $TEMP in bash on Windows (Git Bash) maps to the Windows TEMP dir.
+            # NSIS $TEMP macro also expands to the Windows TEMP dir.
+            E2E_INSTALL_DIR="${TEMP:-/tmp}/NsisE2ETest"
+
+            if [ -f "$E2E_INSTALL_DIR/INSTALLED.txt" ]; then
+                pass "E2E install: INSTALLED.txt created"
+            else
+                fail "E2E install: INSTALLED.txt not found at $E2E_INSTALL_DIR"
+            fi
+
+            UNINSTALLER="$E2E_INSTALL_DIR/Uninstall.exe"
+            if [ -f "$UNINSTALLER" ]; then
+                if $IS_WINDOWS; then
+                    "$UNINSTALLER" /S >/dev/null 2>&1 || true
+                else
+                    wine "$UNINSTALLER" /S >/dev/null 2>&1 || true
+                fi
+                # NSIS uninstallers on Windows copy themselves to TEMP before running;
+                # give the cleanup process a moment to finish.
+                sleep 2
+
+                if [ -f "$E2E_INSTALL_DIR/INSTALLED.txt" ]; then
+                    fail "E2E uninstall: INSTALLED.txt still present after uninstall"
+                else
+                    pass "E2E uninstall: INSTALLED.txt removed"
+                fi
+
+                if [ -d "$E2E_INSTALL_DIR" ]; then
+                    fail "E2E uninstall: install directory still present after uninstall"
+                else
+                    pass "E2E uninstall: install directory removed"
+                fi
+            else
+                fail "E2E uninstall: Uninstall.exe not found at $E2E_INSTALL_DIR"
+            fi
+        else
+            skip "E2E run: requires Windows or Linux+Wine (not available on this platform)"
+        fi
+    fi
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+printf "  Results: %d passed, %d skipped, %d failed\n" "$PASS" "$SKIP" "$FAIL"
+echo "═══════════════════════════════════════════════════════════════"
+echo ""
+
+[ "$FAIL" -eq 0 ]

--- a/packages/nsis/assets/nsis-windows.sh
+++ b/packages/nsis/assets/nsis-windows.sh
@@ -176,9 +176,38 @@ if ! unzip -q "$STRLEN_ZIP" -d "$STRLEN_EXTRACTED"; then
     exit 1
 fi
 
-# Patch over the base NSIS files using rsync
-echo "  → Patching NSIS files"
-rsync -a "$STRLEN_EXTRACTED/" "$NSIS_EXTRACTED/"
+# Apply strlen_8192 patch — copy only patched binaries, leave data files from
+# the official release untouched. The SourceForge zip may extract with a
+# top-level subdirectory; use find so the structure doesn't matter.
+echo "  → Patching binary files..."
+
+STRLEN_MAKENSIS=$(find "$STRLEN_EXTRACTED" -path "*/Bin/makensis.exe" | head -1)
+STRLEN_ZLIB=$(find "$STRLEN_EXTRACTED" -name "zlib1.dll" | head -1)
+STRLEN_STUBS_DIR=$(find "$STRLEN_EXTRACTED" -type d -name "Stubs" | head -1)
+
+if [ -z "$STRLEN_MAKENSIS" ]; then
+    echo "❌ makensis.exe not found in strlen_8192 patch (unexpected zip structure)"
+    exit 1
+fi
+
+cp "$STRLEN_MAKENSIS" "$NSIS_EXTRACTED/Bin/makensis.exe"
+echo "    ✓ Bin/makensis.exe patched"
+
+if [ -n "$STRLEN_ZLIB" ]; then
+    cp "$STRLEN_ZLIB" "$NSIS_EXTRACTED/Bin/zlib1.dll"
+    echo "    ✓ Bin/zlib1.dll patched"
+fi
+
+if [ -n "$STRLEN_STUBS_DIR" ]; then
+    rsync -a "$STRLEN_STUBS_DIR/" "$NSIS_EXTRACTED/Stubs/"
+    echo "    ✓ Stubs/ patched"
+fi
+
+STRLEN_MAKENSISW=$(find "$STRLEN_EXTRACTED" -name "makensisw.exe" | head -1)
+if [ -n "$STRLEN_MAKENSISW" ]; then
+    cp "$STRLEN_MAKENSISW" "$NSIS_EXTRACTED/makensisw.exe"
+    echo "    ✓ makensisw.exe patched (strlen_8192)"
+fi
 
 echo "  ✓ Applied strlen_8192 patch"
 
@@ -189,7 +218,7 @@ echo "  ✓ Applied strlen_8192 patch"
 echo ""
 echo "📚 Copying NSIS data files..."
 
-for item in Bin Contrib Include Plugins Stubs; do
+for item in Bin Contrib Include Menu Plugins Stubs; do
     if [ -d "$NSIS_EXTRACTED/$item" ]; then
         echo "  → $item/"
         rsync -a "$NSIS_EXTRACTED/$item/" "$BUNDLE_DIR/windows/$item/"
@@ -438,7 +467,7 @@ if test -f "$PLUGINS_DIR/nsis7z.7z"; then
         $EXTRACT_CMD $EXTRACT_ARGS "$PLUGINS_DIR/nsis7z.7z" -o"$nsis7z_dir" >/dev/null 2>&1 || true
         
         # Install nsis7z DLLs using rsync
-        for arch in x64-unicode x86-ansi x86-unicode; do
+        for arch in x64-ansi x64-unicode x86-ansi x86-unicode; do
             if [ -d "$nsis7z_dir/Plugins/$arch" ]; then
                 rsync -a --include='nsis7z.dll' --exclude='*' \
                     "$nsis7z_dir/Plugins/$arch/" "$BUNDLE_DIR/windows/Plugins/$arch/"

--- a/packages/nsis/build.sh
+++ b/packages/nsis/build.sh
@@ -32,7 +32,7 @@ case "$OS_TYPE" in
     *) CURRENT_OS="all" ;;
 esac
 
-BUILD_TARGET="${1:-}"
+BUILD_TARGET=""
 
 # =============================================================================
 # Functions
@@ -85,22 +85,24 @@ combine() {
 
 show_usage() {
     cat << EOF
-Usage: $0 [TARGET]
+Usage: $0 --target TARGET
+
+Options:
+  --target, -t TARGET   Build target (required)
+  --help, -h            Show this help
 
 Targets:
   base      Build base bundle (Windows + plugins + data files)
   linux     Build Linux native binary (requires Docker)
   mac       Build macOS native binary (requires macOS)
   all       Build base + current platform binary
-  
-  If no target specified, builds 'all'
 
 Examples:
-  ./build.sh              # Build base + current platform
-  ./build.sh base         # Build only the base bundle
-  ./build.sh linux        # Build Linux binary (requires Docker, builds base if needed)
-  ./build.sh mac          # Build macOS binary (requires macOS, builds base if needed)
-  
+  ./build.sh --target all    # Build base + current platform
+  ./build.sh --target base   # Build only the base bundle
+  ./build.sh --target linux  # Build Linux binary (requires Docker)
+  ./build.sh --target mac    # Build macOS binary (requires macOS)
+
 Platform Requirements:
   Base:   Any OS with bash, curl, unzip
   Linux:  Docker (can run on any OS)
@@ -113,11 +115,13 @@ EOF
 # Main
 # =============================================================================
 
-# Handle help
-if [ "$BUILD_TARGET" = "-h" ] || [ "$BUILD_TARGET" = "--help" ]; then
-    show_usage
-    exit 0
-fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target|-t) BUILD_TARGET="${2:-}"; shift 2 ;;
+        --help|-h)   show_usage; exit 0 ;;
+        *) echo "❌ Unknown option: $1"; echo ""; show_usage; exit 1 ;;
+    esac
+done
 
 # Print banner
 print_banner

--- a/packages/nsis/build.sh
+++ b/packages/nsis/build.sh
@@ -88,20 +88,23 @@ show_usage() {
 Usage: $0 --target TARGET
 
 Options:
-  --target, -t TARGET   Build target (required)
+  --target, -t TARGET   Build target (default: all)
   --help, -h            Show this help
 
 Targets:
-  base      Build base bundle (Windows + plugins + data files)
-  linux     Build Linux native binary (requires Docker)
-  mac       Build macOS native binary (requires macOS)
-  all       Build base + current platform binary
+  base              Build base bundle (Windows + plugins + data files)
+  windows, win      Alias for base
+  linux             Build Linux native binary (requires Docker)
+  mac, macos        Build macOS native binary (requires macOS)
+  combine           Combine previously built platform bundles into final archive
+  all               Build all platforms (base + mac + linux + combine)
 
 Examples:
-  ./build.sh --target all    # Build base + current platform
-  ./build.sh --target base   # Build only the base bundle
-  ./build.sh --target linux  # Build Linux binary (requires Docker)
-  ./build.sh --target mac    # Build macOS binary (requires macOS)
+  ./build.sh --target all     # Build all platforms and combine
+  ./build.sh --target base    # Build only the base bundle
+  ./build.sh --target linux   # Build Linux binary (requires Docker)
+  ./build.sh --target mac     # Build macOS binary (requires macOS)
+  ./build.sh --target combine # Combine existing platform bundles
 
 Platform Requirements:
   Base:   Any OS with bash, curl, unzip
@@ -117,7 +120,14 @@ EOF
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --target|-t) BUILD_TARGET="${2:-}"; shift 2 ;;
+        --target|-t)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "❌ --target requires a value"
+                echo ""
+                show_usage
+                exit 1
+            fi
+            BUILD_TARGET="$2"; shift 2 ;;
         --help|-h)   show_usage; exit 0 ;;
         *) echo "❌ Unknown option: $1"; echo ""; show_usage; exit 1 ;;
     esac


### PR DESCRIPTION
This pull request introduces significant improvements to the NSIS package build, test, and distribution process, focusing on robust cross-platform support, enhanced testing (including new end-to-end tests), and improved plugin handling. The changes streamline the CI workflow, add comprehensive validation for built plugins, and ensure that produced installers work correctly across all supported platforms.

**Key changes include:**

* Refactored the GitHub Actions workflow (`.github/workflows/build-nsis.yaml`) to use a unified build command syntax, add platform-specific matrix variables, and introduce a new E2E install/uninstall test job for installers produced on all platforms. This includes a new step to run a smoke test on all 16 built-in plugins and a compile test for each platform.
* Added a new script `nsis-e2e-install.sh` to automate install and uninstall verification for each compiled installer, ensuring that the installer works as expected on all platforms.
* Improved the platform dispatch logic in `nsis-combine.sh` to better handle macOS, Linux, and Windows environments, including correct handling of PowerShell and CMD entrypoints, and normalization of paths for Windows runners. Also, added a legacy `mac/makensis` binary for backward compatibility.

### Plugin and Bundle Content Updates

* Updated the documentation and bundle contents to reflect the inclusion of 10 community plugins (up from 8), with accurate descriptions for each.

### Build Script Fixes and Improvements

* Improved the macOS build script to detect the Homebrew prefix for header/library paths, making the build more robust on both Intel and Apple Silicon Macs.
* Refined the Windows build script to apply the `strlen_8192` patch more precisely, copying only patched binaries and not overwriting official data files, and ensuring all necessary directories are included in the bundle.
* Added validation of plugin DLL PE headers and a compile smoke test for all 16 built-in plugins, improving the reliability of plugin builds.