### PR TITLE
feat(nsis): compile elevate.exe from source

### DIFF
--- a/.changeset/ninety-geckos-wave.md
+++ b/.changeset/ninety-geckos-wave.md
@@ -1,0 +1,5 @@
+---
+"nsis": minor
+---
+
+feat(nsis): compile elevate.exe from source

--- a/.github/workflows/build-nsis.yaml
+++ b/.github/workflows/build-nsis.yaml
@@ -90,11 +90,35 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # Build elevate.exe from source inside Docker
+  elevate:
+    name: Build elevate.exe
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Build elevate.exe
+        run: bash ./build.sh --target elevate
+        shell: bash
+        working-directory: ./packages/nsis
+
+      - name: Upload elevate artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: nsis-temp-elevate
+          path: packages/nsis/out/**/*.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
   # Combine all artifacts into final bundle
   combine-artifacts:
     name: Combine All Bundles
     runs-on: macos-latest
-    needs: [base, mac, linux]
+    needs: [base, mac, linux, elevate]
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/packages/nsis/assets/nsis-combine.sh
+++ b/packages/nsis/assets/nsis-combine.sh
@@ -43,6 +43,7 @@ MAC_BUNDLES=()
 while IFS= read -r _line; do
     [[ -n "$_line" ]] && MAC_BUNDLES+=("$_line")
 done < <(find "$OUT_DIR" -name "nsis-bundle-mac-*.tar.gz" -type f)
+ELEVATE_BUNDLE=$(find "$OUT_DIR" -name "nsis-bundle-elevate-*.tar.gz" -type f | head -1)
 # Validate base bundle
 if [ -z "$BASE_BUNDLE" ] || [ ! -f "$BASE_BUNDLE" ]; then
     echo "❌ Base bundle not found in $OUT_DIR"
@@ -66,6 +67,12 @@ else
     echo "  ⚠️  macOS:        not found (skipping)"
 fi
 
+if [ -z "$ELEVATE_BUNDLE" ] || [ ! -f "$ELEVATE_BUNDLE" ]; then
+    echo "❌ Elevate bundle not found in $OUT_DIR"
+    exit 1
+fi
+echo "  ✓ Elevate:      $(basename "$ELEVATE_BUNDLE")"
+
 # =============================================================================
 # Extract Base Bundle
 # =============================================================================
@@ -82,6 +89,19 @@ if [ ! -d "$BUILD_DIR/nsis-bundle" ]; then
 fi
 
 echo "  ✓ Base bundle extracted"
+
+# =============================================================================
+# Inject elevate.exe
+# =============================================================================
+
+echo ""
+echo "⬆️  Injecting elevate.exe..."
+TEMP_ELEVATE="$BUILD_DIR/temp-elevate"
+mkdir -p "$TEMP_ELEVATE"
+tar -xzf "$ELEVATE_BUNDLE" -C "$TEMP_ELEVATE"
+cp "$TEMP_ELEVATE/nsis-bundle/elevate.exe" "$BUILD_DIR/nsis-bundle/elevate.exe"
+rm -rf "$TEMP_ELEVATE" "$ELEVATE_BUNDLE"
+echo "  ✓ elevate.exe injected"
 
 # =============================================================================
 # Inject Linux Binary

--- a/packages/nsis/assets/nsis-combine.sh
+++ b/packages/nsis/assets/nsis-combine.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # =============================================================================
 # NSIS Bundle Combiner
 # =============================================================================
-# Combines base, Linux, and macOS bundles into a single complete bundle
+# Combines base, Linux, macOS, and elevate bundles into a single complete bundle
 # Generates universal entrypoint wrapper script
 # =============================================================================
 
@@ -99,6 +99,10 @@ echo "⬆️  Injecting elevate.exe..."
 TEMP_ELEVATE="$BUILD_DIR/temp-elevate"
 mkdir -p "$TEMP_ELEVATE"
 tar -xzf "$ELEVATE_BUNDLE" -C "$TEMP_ELEVATE"
+if [ ! -f "$TEMP_ELEVATE/nsis-bundle/elevate.exe" ]; then
+    echo "❌ elevate.exe not found at expected path in bundle: $TEMP_ELEVATE/nsis-bundle/elevate.exe"
+    exit 1
+fi
 cp "$TEMP_ELEVATE/nsis-bundle/elevate.exe" "$BUILD_DIR/nsis-bundle/elevate.exe"
 rm -rf "$TEMP_ELEVATE" "$ELEVATE_BUNDLE"
 echo "  ✓ elevate.exe injected"
@@ -335,6 +339,7 @@ This bundle contains NSIS (Nullsoft Scriptable Install System) binaries for mult
 - **Windows**: \`windows/makensis.exe\` (official pre-built binary)
 - **Linux**: \`linux/makensis\` (native ELF binary, compiled from source)
 - **macOS**: \`mac/makensis\` (native Mach-O binary, compiled from source)
+- **Elevate**: \`elevate.exe\` (Windows privilege elevation utility, compiled from source)
 - **NSIS Data**: \`windows/\` (Contrib, Include, Plugins, Stubs)
 - **Universal Wrapper**: \`makensis\` (auto-detects platform, sets \`NSISDIR\`) [.cmd and .ps1 versions for Windows]
 

--- a/packages/nsis/assets/nsis-elevate.sh
+++ b/packages/nsis/assets/nsis-elevate.sh
@@ -24,7 +24,8 @@ ELEVATE_VERSION="1.3.0"
 ELEVATE_SHA256="b1b3f070353a0eadee2cea3a575049d10df9763ff24e39313da4cec9455382e1"
 
 # Docker configuration
-IMAGE_NAME="nsis-elevate-builder:${NSIS_BRANCH}"
+IMAGE_TAG="${NSIS_BRANCH//\//_}"
+IMAGE_NAME="nsis-elevate-builder:${IMAGE_TAG}"
 CONTAINER_NAME="nsis-elevate-build-$$"
 
 OUTPUT_ARCHIVE="$OUT_DIR/nsis-bundle-elevate-$NSIS_BRANCH.tar.gz"
@@ -58,6 +59,8 @@ cleanup() {
     echo ""
     echo "🧹 Cleaning up Docker resources..."
     docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    [ -n "${DOCKERFILE:-}" ] && rm -f "$DOCKERFILE" 2>/dev/null || true
+    [ -n "${TEMP_DIR:-}" ] && rm -rf "$TEMP_DIR" 2>/dev/null || true
 }
 trap cleanup EXIT INT TERM
 
@@ -137,8 +140,7 @@ docker build \
     --build-arg ELEVATE_VERSION="$ELEVATE_VERSION" \
     --build-arg ELEVATE_SHA256="$ELEVATE_SHA256" \
     -t "$IMAGE_NAME" \
-    -f "$DOCKERFILE" \
-    "$OUT_DIR"
+    - < "$DOCKERFILE"
 
 if [ $? -ne 0 ]; then
     echo "❌ Docker build failed"

--- a/packages/nsis/assets/nsis-elevate.sh
+++ b/packages/nsis/assets/nsis-elevate.sh
@@ -103,20 +103,27 @@ RUN i686-w64-mingw32-windres \
     --include-dir src -D NDEBUG -D _M_IX86 \
     src/elevate.rc -o src/elevate-res.o
 
+# _pei386_runtime_relocator is referenced by the linker's pseudo-reloc stub but lives in
+# the CRT startup objects excluded by -nostdlib. Provide a no-op: it is never called
+# because -Wl,-e,_elevate bypasses CRT startup entirely.
+RUN printf 'void __cdecl _pei386_runtime_relocator(void) {}\n' \
+    | i686-w64-mingw32-gcc -x c -c -o src/pei386_stub.o -
+
 # Compile 32-bit stripped console binary.
-# -nostartfiles + -Wl,-e,_elevate mirrors MSVC's /entry:elevate.
+# -nostdlib + -Wl,-e,_elevate mirrors MSVC's /entry:elevate.
 # Safe because the source calls ExitProcess() at every exit path.
 RUN mkdir -p /output && \
     i686-w64-mingw32-gcc \
         -DUNICODE -D_UNICODE -D_WIN32_WINNT=0x0600 \
         '-D__forceinline=__attribute__((always_inline))' \
         -O2 -s \
-        -nostartfiles -Wl,-e,_elevate \
+        -nostdlib -Wl,-e,_elevate \
         -I src \
         -o /output/elevate.exe \
-        src/elevate_patched.c src/elevate-res.o \
+        src/elevate_patched.c src/elevate-res.o src/pei386_stub.o \
+        -lmingwex -lmsvcrt \
         -lkernel32 -lshell32 \
-        -static-libgcc
+        -lgcc
 DOCKERFILE_END
 
 # =============================================================================

--- a/packages/nsis/assets/nsis-elevate.sh
+++ b/packages/nsis/assets/nsis-elevate.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# elevate.exe Builder (Docker-based)
+# =============================================================================
+# Compiles elevate.exe 1.3.0 from source inside a Docker container.
+# Does NOT download or merge with base bundle.
+# Output: Single tar.gz with just elevate.exe at the bundle root.
+#
+# Mirrors the structure of nsis-linux.sh.
+# Testable on macOS (Docker Desktop / Colima) and Linux.
+# =============================================================================
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+BASE_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+OUT_DIR="$BASE_DIR/out/nsis"
+
+# Version configuration
+NSIS_BRANCH=${NSIS_BRANCH_OR_COMMIT:-v312}
+
+# Elevate source
+ELEVATE_VERSION="1.3.0"
+ELEVATE_SHA256="b1b3f070353a0eadee2cea3a575049d10df9763ff24e39313da4cec9455382e1"
+
+# Docker configuration
+IMAGE_NAME="nsis-elevate-builder:${NSIS_BRANCH}"
+CONTAINER_NAME="nsis-elevate-build-$$"
+
+OUTPUT_ARCHIVE="$OUT_DIR/nsis-bundle-elevate-$NSIS_BRANCH.tar.gz"
+
+echo "⬆️  Building elevate.exe from source (Docker)..."
+echo "   elevate version: $ELEVATE_VERSION"
+echo "   Branch:          $NSIS_BRANCH"
+echo ""
+
+# =============================================================================
+# Setup
+# =============================================================================
+
+mkdir -p "$OUT_DIR"
+
+# =============================================================================
+# Check Prerequisites
+# =============================================================================
+
+if ! command -v docker &> /dev/null; then
+    echo "❌ Docker is required but not installed"
+    echo "   Install Docker: https://docs.docker.com/get-docker/"
+    exit 1
+fi
+
+# =============================================================================
+# Cleanup Handler
+# =============================================================================
+
+cleanup() {
+    echo ""
+    echo "🧹 Cleaning up Docker resources..."
+    docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# =============================================================================
+# Create Dockerfile
+# =============================================================================
+
+echo "📝 Creating Dockerfile for elevate.exe build..."
+
+DOCKERFILE="$OUT_DIR/Dockerfile.elevate"
+
+cat > "$DOCKERFILE" <<'DOCKERFILE_END'
+FROM ubuntu:22.04
+
+ARG ELEVATE_VERSION
+ARG ELEVATE_SHA256
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    p7zip-full \
+    mingw-w64 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Download and SHA256-verify the source archive inside the container.
+RUN curl -fsSL \
+    "https://code.kliu.org/misc/elevate/elevate-${ELEVATE_VERSION}-redist.7z" \
+    -o elevate-redist.7z && \
+    echo "${ELEVATE_SHA256}  elevate-redist.7z" | sha256sum -c
+
+# Extract only the src/ tree (preserves the libs/ subdirectory used by #include)
+RUN 7z x elevate-redist.7z "src/" -y
+
+# GCC on Linux does not normalise backslashes in #include paths;
+# patch the one backslash path before compiling.
+RUN sed 's|libs\\SimpleString.h|libs/SimpleString.h|' \
+    src/elevate.c > src/elevate_patched.c
+
+# Compile resource file (embeds UAC manifest + version info)
+RUN i686-w64-mingw32-windres \
+    --include-dir src -D NDEBUG -D _M_IX86 \
+    src/elevate.rc -o src/elevate-res.o
+
+# Compile 32-bit stripped console binary.
+# -nostartfiles + -Wl,-e,_elevate mirrors MSVC's /entry:elevate.
+# Safe because the source calls ExitProcess() at every exit path.
+RUN mkdir -p /output && \
+    i686-w64-mingw32-gcc \
+        -DUNICODE -D_UNICODE -D_WIN32_WINNT=0x0600 \
+        '-D__forceinline=__attribute__((always_inline))' \
+        -O2 -s \
+        -nostartfiles -Wl,-e,_elevate \
+        -I src \
+        -o /output/elevate.exe \
+        src/elevate_patched.c src/elevate-res.o \
+        -lkernel32 -lshell32 \
+        -static-libgcc
+DOCKERFILE_END
+
+# =============================================================================
+# Build Docker Image
+# =============================================================================
+
+echo ""
+echo "🔨 Building Docker image..."
+
+docker build \
+    --build-arg ELEVATE_VERSION="$ELEVATE_VERSION" \
+    --build-arg ELEVATE_SHA256="$ELEVATE_SHA256" \
+    -t "$IMAGE_NAME" \
+    -f "$DOCKERFILE" \
+    "$OUT_DIR"
+
+if [ $? -ne 0 ]; then
+    echo "❌ Docker build failed"
+    exit 1
+fi
+
+echo "  ✓ Docker image built successfully"
+
+# =============================================================================
+# Extract Compiled Binary
+# =============================================================================
+
+echo ""
+echo "📦 Extracting compiled elevate.exe..."
+
+docker create --name "$CONTAINER_NAME" "$IMAGE_NAME" /bin/true
+
+TEMP_DIR="$OUT_DIR/temp-elevate"
+rm -rf "$TEMP_DIR"
+mkdir -p "$TEMP_DIR/nsis-bundle"
+
+docker cp "$CONTAINER_NAME:/output/elevate.exe" "$TEMP_DIR/nsis-bundle/elevate.exe"
+
+if [ ! -f "$TEMP_DIR/nsis-bundle/elevate.exe" ]; then
+    echo "❌ Failed to extract elevate.exe from container"
+    exit 1
+fi
+
+echo "  ✓ elevate.exe extracted"
+
+# =============================================================================
+# Verify Binary (PE MZ header)
+# =============================================================================
+
+echo "  → Verifying binary..."
+
+MZ=$(od -N 2 -A n -t x1 "$TEMP_DIR/nsis-bundle/elevate.exe" 2>/dev/null | tr -d ' \n')
+if [ "$MZ" = "4d5a" ]; then
+    echo "  ✓ Valid PE binary (MZ header)"
+else
+    echo "  ❌ Binary verification failed: not a valid PE (MZ header check failed)"
+    exit 1
+fi
+
+# =============================================================================
+# Create Archive
+# =============================================================================
+
+echo ""
+echo "📦 Creating elevate bundle archive..."
+
+cd "$TEMP_DIR"
+tar -czf "${OUTPUT_ARCHIVE}" nsis-bundle
+
+# =============================================================================
+# Cleanup
+# =============================================================================
+
+rm -f "$DOCKERFILE"
+rm -rf "$TEMP_DIR"
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+echo ""
+echo "================================================================"
+echo "  ✅ elevate.exe Build Complete!"
+echo "================================================================"
+echo "  📁 Archive: $OUTPUT_ARCHIVE"
+echo "  📊 Size:    $(du -h "$OUTPUT_ARCHIVE" | cut -f1)"
+echo "================================================================"
+echo ""

--- a/packages/nsis/assets/nsis-test.sh
+++ b/packages/nsis/assets/nsis-test.sh
@@ -126,6 +126,16 @@ assert_file "$BUNDLE_DIR/windows/makensis.exe"          "windows/makensis.exe (c
 assert_file "$BUNDLE_DIR/windows/Bin/makensis.exe"      "windows/Bin/makensis.exe (strlen-patched) present"
 assert_file "$BUNDLE_DIR/linux/makensis"                "linux/makensis present"
 assert_file "$BUNDLE_DIR/mac/makensis"             "mac/makensis (legacy flat) present"
+assert_file "$BUNDLE_DIR/elevate.exe"              "elevate.exe present at bundle root"
+
+if [ -f "$BUNDLE_DIR/elevate.exe" ]; then
+    MZ_ELV=$(od -N 2 -A n -t x1 "$BUNDLE_DIR/elevate.exe" 2>/dev/null | tr -d ' \n')
+    if [ "$MZ_ELV" = "4d5a" ]; then
+        pass "elevate.exe: valid PE binary (MZ header)"
+    else
+        fail "elevate.exe: invalid MZ header (got: $MZ_ELV)"
+    fi
+fi
 
 if $IS_MAC; then
     # Current arch is required; opposite arch is opportunistic

--- a/packages/nsis/build.sh
+++ b/packages/nsis/build.sh
@@ -68,12 +68,19 @@ build_mac() {
     bash "$ASSETS_DIR/nsis-mac.sh"
 }
 
+build_elevate() {
+    echo "⬆️  Building elevate.exe (Docker)..."
+    echo ""
+    bash "$ASSETS_DIR/nsis-elevate.sh"
+}
+
 build_all() {
     echo "🌍 Building all available platforms..."
     echo ""
     build_base
     build_mac
     build_linux
+    build_elevate
     combine
 }
 
@@ -96,8 +103,9 @@ Targets:
   windows, win      Alias for base
   linux             Build Linux native binary (requires Docker)
   mac, macos        Build macOS native binary (requires macOS)
+  elevate           Build elevate.exe from source (requires Docker)
   combine           Combine previously built platform bundles into final archive
-  all               Build all platforms (base + mac + linux + combine)
+  all               Build all platforms (base + mac + linux + elevate + combine)
 
 Examples:
   ./build.sh --target all     # Build all platforms and combine
@@ -149,6 +157,9 @@ case "$BUILD_TARGET" in
         ;;
     mac|macos|darwin)
         build_mac
+        ;;
+    elevate)
+        build_elevate
         ;;
     combine)
         combine


### PR DESCRIPTION
This pull request adds automated building, packaging, and integration of `elevate.exe` (a Windows privilege elevation utility) into the NSIS distribution process. The changes ensure that `elevate.exe` is built from source using Docker, verified, and included in the final NSIS bundle. The build and test scripts, as well as the GitHub Actions workflow, have been updated to support this new step.

- Added a new `elevate` job to the GitHub Actions workflow (`.github/workflows/build-nsis.yaml`) to build `elevate.exe` from source inside Docker, upload it as an artifact, and ensure the final bundle job depends on it.