### PR TITLE
chore(CI/CD): only build packages in PRs that have been actually changeset'd in that PR

### DIFF
--- a/scripts/detect-packages.sh
+++ b/scripts/detect-packages.sh
@@ -2,7 +2,11 @@ set -exu
 
 # Output changesets release candidates to a temporary file
 TMP_JSON=changeset-status.json
-pnpm changeset status --output "$TMP_JSON"
+SINCE_ARGS=""
+if [ -n "${GITHUB_BASE_REF:-}" ]; then
+    SINCE_ARGS="--since=origin/${GITHUB_BASE_REF}"
+fi
+pnpm changeset status --output "$TMP_JSON" $SINCE_ARGS
 
 # Ensure the file exists and is valid JSON
 if [ ! -s "$TMP_JSON" ]; then


### PR DESCRIPTION
Pass `--since=origin/${GITHUB_BASE_REF}` to changeset status on PR events, so only changeset files introduced in the current branch are considered.