### PR TITLE
feat(nsis): adding arm64 linux `makensis` binary to the package

### DIFF
--- a/.changeset/tidy-spies-make.md
+++ b/.changeset/tidy-spies-make.md
@@ -1,0 +1,5 @@
+---
+"nsis": minor
+---
+
+feat(nsis): adding compilation of linux arm64 `makensis` binary

--- a/.github/workflows/build-nsis.yaml
+++ b/.github/workflows/build-nsis.yaml
@@ -71,6 +71,9 @@ jobs:
     name: Build Linux Binary
     runs-on: ubuntu-latest
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 

--- a/packages/nsis/assets/nsis-combine.sh
+++ b/packages/nsis/assets/nsis-combine.sh
@@ -194,7 +194,7 @@ case "$UNAME_S" in
     case "$ARCH" in
       x86_64) ARCH_DIR="x64" ;;
       arm64)  ARCH_DIR="arm64" ;;
-      *)      ARCH_DIR="$ARCH" ;;
+      *) echo "❌ Unsupported architecture: $UNAME_M" >&2; exit 1 ;;
     esac
     BINARY="$SCRIPT_DIR/mac/$ARCH_DIR/makensis"
     ;;
@@ -202,7 +202,7 @@ case "$UNAME_S" in
     case "$ARCH" in
       x86_64) ARCH_DIR="x64" ;;
       arm64)  ARCH_DIR="arm64" ;;
-      *)      ARCH_DIR="$ARCH" ;;
+      *) echo "❌ Unsupported architecture: $UNAME_M" >&2; exit 1 ;;
     esac
     BINARY="$SCRIPT_DIR/linux/$ARCH_DIR/makensis"
     ;;

--- a/packages/nsis/assets/nsis-combine.sh
+++ b/packages/nsis/assets/nsis-combine.sh
@@ -199,7 +199,12 @@ case "$UNAME_S" in
     BINARY="$SCRIPT_DIR/mac/$ARCH_DIR/makensis"
     ;;
   Linux)
-    BINARY="$SCRIPT_DIR/linux/makensis"
+    case "$ARCH" in
+      x86_64) ARCH_DIR="x64" ;;
+      arm64)  ARCH_DIR="arm64" ;;
+      *)      ARCH_DIR="$ARCH" ;;
+    esac
+    BINARY="$SCRIPT_DIR/linux/$ARCH_DIR/makensis"
     ;;
   MINGW*|MSYS*|CYGWIN*)
     # makensisw.exe is GUI-subsystem. -VERSION triggers a MessageBox (hangs in
@@ -325,7 +330,7 @@ This bundle contains NSIS (Nullsoft Scriptable Install System) binaries for mult
 ## Contents
 
 - **Windows**: \`windows/makensis.exe\` (official pre-built binary)
-- **Linux**: \`linux/makensis\` (native ELF binary, compiled from source)
+- **Linux**: \`linux/x64/makensis\` and \`linux/arm64/makensis\` (native ELF binaries, compiled from source)
 - **macOS**: \`mac/makensis\` (native Mach-O binary, compiled from source)
 - **Elevate**: \`elevate.exe\` (Windows privilege elevation utility, compiled from source)
 - **NSIS Data**: \`windows/\` (Contrib, Include, Plugins, Stubs)
@@ -356,7 +361,8 @@ export NSISDIR="\$(pwd)/windows"
 
 # Run platform-specific binary
 ./windows/makensis.exe your-script.nsi  # Windows
-./linux/makensis your-script.nsi         # Linux
+./linux/x64/makensis your-script.nsi     # Linux x64
+./linux/arm64/makensis your-script.nsi   # Linux arm64
 ./mac/makensis your-script.nsi           # macOS
 \`\`\`
 

--- a/packages/nsis/assets/nsis-linux.sh
+++ b/packages/nsis/assets/nsis-linux.sh
@@ -17,13 +17,9 @@ OUT_DIR="$BASE_DIR/out/nsis"
 NSIS_VERSION=${NSIS_VERSION:-3.12}
 NSIS_BRANCH=${NSIS_BRANCH_OR_COMMIT:-v312}
 
-# Docker configuration
-IMAGE_NAME="nsis-linux-builder:${NSIS_BRANCH}"
-CONTAINER_NAME="nsis-linux-build-$$"
-
 OUTPUT_ARCHIVE="$OUT_DIR/nsis-bundle-linux-$NSIS_BRANCH.tar.gz"
 
-echo "🐧 Building native Linux makensis binary..."
+echo "🐧 Building native Linux makensis binaries (amd64, arm64)..."
 echo "   Version: $NSIS_VERSION"
 echo "   Branch:  $NSIS_BRANCH"
 echo ""
@@ -44,14 +40,21 @@ if ! command -v docker &> /dev/null; then
     exit 1
 fi
 
+if ! docker buildx version &> /dev/null; then
+    echo "❌ Docker buildx is required but not available"
+    exit 1
+fi
+
 # =============================================================================
 # Cleanup Handler
 # =============================================================================
 
+BUILDX_BUILDER="nsis-linux-builder-$$"
+
 cleanup() {
     echo ""
     echo "🧹 Cleaning up Docker resources..."
-    docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    docker buildx rm "$BUILDX_BUILDER" 2>/dev/null || true
 }
 trap cleanup EXIT INT TERM
 
@@ -92,7 +95,7 @@ RUN scons \
     SKIPUTILS=all \
     SKIPMISC=all \
     NSIS_CONFIG_CONST_DATA_PATH=no \
-    NSIS_CONFIG_LOG=yes \
+    NSIS_CONFIG_LOG=no \
     NSIS_MAX_STRLEN=8192 \
     PREFIX=/build/install \
     install-compiler
@@ -106,59 +109,55 @@ RUN mkdir -p /output && \
 DOCKERFILE_END
 
 # =============================================================================
-# Build Docker Image
+# Build Docker Images (multi-platform)
 # =============================================================================
 
 echo ""
-echo "🔨 Building Docker image (this may take 5-10 minutes on first run)..."
+echo "🔨 Building Docker images for amd64 and arm64 (this may take 10-20 minutes on first run)..."
 
-docker build \
+TEMP_DIR="$OUT_DIR/temp-linux"
+rm -rf "$TEMP_DIR"
+mkdir -p "$TEMP_DIR/docker-out"
+mkdir -p "$TEMP_DIR/nsis-bundle/linux/x64"
+mkdir -p "$TEMP_DIR/nsis-bundle/linux/arm64"
+
+docker buildx create --name "$BUILDX_BUILDER" --use
+
+docker buildx build \
+    --platform "linux/amd64,linux/arm64" \
     --build-arg NSIS_BRANCH="$NSIS_BRANCH" \
-    -t "$IMAGE_NAME" \
+    --output "type=local,dest=${TEMP_DIR}/docker-out" \
     -f "$DOCKERFILE" \
     "$OUT_DIR"
 
-if [ $? -ne 0 ]; then
-    echo "❌ Docker build failed"
-    exit 1
-fi
-
-echo "  ✓ Docker image built successfully"
+echo "  ✓ Docker images built successfully"
 
 # =============================================================================
-# Extract Compiled Binary
+# Extract Compiled Binaries
 # =============================================================================
 
 echo ""
-echo "📦 Extracting compiled Linux binary..."
+echo "📦 Extracting compiled Linux binaries..."
 
-# Create container
-docker create --name "$CONTAINER_NAME" "$IMAGE_NAME" /bin/true
+cp "$TEMP_DIR/docker-out/linux_amd64/output/makensis" "$TEMP_DIR/nsis-bundle/linux/x64/makensis"
+cp "$TEMP_DIR/docker-out/linux_arm64/output/makensis" "$TEMP_DIR/nsis-bundle/linux/arm64/makensis"
+chmod +x "$TEMP_DIR/nsis-bundle/linux/x64/makensis" "$TEMP_DIR/nsis-bundle/linux/arm64/makensis"
+rm -rf "$TEMP_DIR/docker-out"
 
-# Create temp directory for extraction
-TEMP_DIR="$OUT_DIR/temp-linux"
-rm -rf "$TEMP_DIR"
-mkdir -p "$TEMP_DIR/nsis-bundle/linux"
-
-# Copy binary from container
-docker cp "$CONTAINER_NAME:/output/makensis" "$TEMP_DIR/nsis-bundle/linux/makensis"
-
-if [ ! -f "$TEMP_DIR/nsis-bundle/linux/makensis" ]; then
-    echo "❌ Failed to extract Linux binary"
-    exit 1
-fi
-
-chmod +x "$TEMP_DIR/nsis-bundle/linux/makensis"
-echo "  ✓ Linux binary extracted"
-
-# Verify binary
-echo "  → Verifying binary..."
-if file "$TEMP_DIR/nsis-bundle/linux/makensis" | grep -q "ELF"; then
-    echo "  ✓ Valid Linux ELF binary"
-else
-    echo "  ❌ Binary verification failed: not a valid Linux ELF binary"
-    exit 1
-fi
+echo "  → Verifying binaries..."
+for arch_dir in x64 arm64; do
+    bin="$TEMP_DIR/nsis-bundle/linux/$arch_dir/makensis"
+    if [ ! -f "$bin" ]; then
+        echo "  ❌ Binary not found: $bin"
+        exit 1
+    fi
+    if file "$bin" | grep -q "ELF"; then
+        echo "  ✓ Valid Linux ELF binary ($arch_dir)"
+    else
+        echo "  ❌ Binary verification failed for $arch_dir: not a valid ELF"
+        exit 1
+    fi
+done
 
 # =============================================================================
 # Create Version Metadata
@@ -170,7 +169,7 @@ echo "📝 Creating version metadata..."
 cat > "$TEMP_DIR/nsis-bundle/linux/VERSION.txt" <<EOF
 Platform: Linux
 Binary: makensis (native ELF binary)
-Architecture: x86_64
+Architectures: x64, arm64
 Build Date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 Compiled from source: NSIS $NSIS_BRANCH
 Compiler: GCC (Ubuntu 22.04)
@@ -184,7 +183,8 @@ This binary is compiled from source with:
 
 Usage:
   export NSISDIR="\$(pwd)/share/nsis"
-  ./linux/makensis your-script.nsi
+  ./linux/x64/makensis your-script.nsi   # x86_64
+  ./linux/arm64/makensis your-script.nsi # aarch64
 EOF
 
 # =============================================================================

--- a/packages/nsis/assets/nsis-mac.sh
+++ b/packages/nsis/assets/nsis-mac.sh
@@ -113,7 +113,7 @@ if ! scons \
     SKIPUTILS=all \
     SKIPMISC=all \
     NSIS_CONFIG_CONST_DATA_PATH=no \
-    NSIS_CONFIG_LOG=yes \
+    NSIS_CONFIG_LOG=no \
     NSIS_MAX_STRLEN=8192 \
     $SCONS_BREW_FLAGS \
     PREFIX="$BUILD_DIR/install" \

--- a/packages/nsis/assets/nsis-test.sh
+++ b/packages/nsis/assets/nsis-test.sh
@@ -53,9 +53,9 @@ esac
 
 ARCH=$(uname -m 2>/dev/null || echo "unknown")
 case "$ARCH" in
-    x86_64|amd64)  MAC_ARCH_DIR="x64" ;;
-    arm64|aarch64) MAC_ARCH_DIR="arm64" ;;
-    *)             MAC_ARCH_DIR="$ARCH" ;;
+    x86_64|amd64)  ARCH_DIR="x64" ;;
+    arm64|aarch64) ARCH_DIR="arm64" ;;
+    *)             ARCH_DIR="$ARCH" ;;
 esac
 
 # =============================================================================
@@ -115,7 +115,8 @@ assert_file "$BUNDLE_DIR/makensis.ps1" "makensis.ps1 present"
 
 # =============================================================================
 # TEST 2 — Binary presence
-# Platform-specific arch binaries are required when running on that platform.
+# All Linux binaries (x64 + arm64) are always required in the bundle regardless
+# of host platform. macOS: native arch is required; opposite arch is opportunistic.
 # =============================================================================
 
 echo ""
@@ -124,7 +125,8 @@ echo "── Test 2: Binary presence ──────────────�
 assert_file "$BUNDLE_DIR/windows/makensisw.exe"         "windows/makensisw.exe present"
 assert_file "$BUNDLE_DIR/windows/makensis.exe"          "windows/makensis.exe (console stub) present"
 assert_file "$BUNDLE_DIR/windows/Bin/makensis.exe"      "windows/Bin/makensis.exe (strlen-patched) present"
-assert_file "$BUNDLE_DIR/linux/makensis"                "linux/makensis present"
+assert_file "$BUNDLE_DIR/linux/x64/makensis"            "linux/x64/makensis present"
+assert_file "$BUNDLE_DIR/linux/arm64/makensis"          "linux/arm64/makensis present"
 assert_file "$BUNDLE_DIR/elevate.exe"              "elevate.exe present at bundle root"
 
 if [ -f "$BUNDLE_DIR/elevate.exe" ]; then
@@ -138,8 +140,8 @@ fi
 
 if $IS_MAC; then
     # Current arch is required; opposite arch is opportunistic
-    assert_file "$BUNDLE_DIR/mac/$MAC_ARCH_DIR/makensis" "mac/$MAC_ARCH_DIR/makensis present"
-    OTHER_ARCH="arm64"; [ "$MAC_ARCH_DIR" = "arm64" ] && OTHER_ARCH="x64"
+    assert_file "$BUNDLE_DIR/mac/$ARCH_DIR/makensis" "mac/$ARCH_DIR/makensis present"
+    OTHER_ARCH="arm64"; [ "$ARCH_DIR" = "arm64" ] && OTHER_ARCH="x64"
     if [ -f "$BUNDLE_DIR/mac/$OTHER_ARCH/makensis" ]; then
         pass "mac/$OTHER_ARCH/makensis present (multi-arch build)"
     else
@@ -156,41 +158,48 @@ echo ""
 echo "── Test 3: Binary format ───────────────────────────────────────"
 
 if $IS_LINUX; then
-    if command -v file &>/dev/null; then
-        FILE_OUT=$(file "$BUNDLE_DIR/linux/makensis")
-        if echo "$FILE_OUT" | grep -q "ELF"; then
-            pass "linux/makensis: valid ELF binary"
+    for linux_arch in x64 arm64; do
+        linux_bin="$BUNDLE_DIR/linux/$linux_arch/makensis"
+        if [ -f "$linux_bin" ]; then
+            if command -v file &>/dev/null; then
+                FILE_OUT=$(file "$linux_bin")
+                if echo "$FILE_OUT" | grep -q "ELF"; then
+                    pass "linux/$linux_arch/makensis: valid ELF binary"
+                else
+                    fail "linux/$linux_arch/makensis: not ELF (got: $FILE_OUT)"
+                fi
+            else
+                # od fallback: ELF magic = 7f 45 4c 46
+                ELF_MAGIC=$(od -N 4 -A n -t x1 "$linux_bin" 2>/dev/null | tr -d ' \n')
+                if [ "$ELF_MAGIC" = "7f454c46" ]; then
+                    pass "linux/$linux_arch/makensis: valid ELF binary (magic bytes)"
+                else
+                    fail "linux/$linux_arch/makensis: ELF magic check failed (got: '$ELF_MAGIC')"
+                fi
+            fi
         else
-            fail "linux/makensis: not ELF (got: $FILE_OUT)"
+            fail "linux/$linux_arch/makensis: file not found"
         fi
-    else
-        # od fallback: ELF magic = 7f 45 4c 46
-        ELF_MAGIC=$(od -N 4 -A n -t x1 "$BUNDLE_DIR/linux/makensis" 2>/dev/null | tr -d ' \n')
-        if [ "$ELF_MAGIC" = "7f454c46" ]; then
-            pass "linux/makensis: valid ELF binary (magic bytes)"
-        else
-            fail "linux/makensis: ELF magic check failed (got: '$ELF_MAGIC')"
-        fi
-    fi
+    done
 fi
 
 if $IS_MAC; then
-    MAC_BIN="$BUNDLE_DIR/mac/$MAC_ARCH_DIR/makensis"
+    MAC_BIN="$BUNDLE_DIR/mac/$ARCH_DIR/makensis"
     [ -f "$MAC_BIN" ] || MAC_BIN="$BUNDLE_DIR/mac/makensis"
     if command -v file &>/dev/null; then
         FILE_OUT=$(file "$MAC_BIN")
         if echo "$FILE_OUT" | grep -q "Mach-O"; then
-            pass "mac/$MAC_ARCH_DIR/makensis: valid Mach-O binary"
+            pass "mac/$ARCH_DIR/makensis: valid Mach-O binary"
         else
-            fail "mac/$MAC_ARCH_DIR/makensis: not Mach-O (got: $FILE_OUT)"
+            fail "mac/$ARCH_DIR/makensis: not Mach-O (got: $FILE_OUT)"
         fi
     else
         # od fallback: Mach-O magics (little-endian 32/64bit or fat binary)
         MAC_MAGIC=$(od -N 4 -A n -t x1 "$MAC_BIN" 2>/dev/null | tr -d ' \n')
         if echo "$MAC_MAGIC" | grep -qE "^(cefaedfe|cffaedfe|cafebabe)"; then
-            pass "mac/$MAC_ARCH_DIR/makensis: valid Mach-O binary (magic bytes)"
+            pass "mac/$ARCH_DIR/makensis: valid Mach-O binary (magic bytes)"
         else
-            fail "mac/$MAC_ARCH_DIR/makensis: Mach-O magic check failed (got: '$MAC_MAGIC')"
+            fail "mac/$ARCH_DIR/makensis: Mach-O magic check failed (got: '$MAC_MAGIC')"
         fi
     fi
 fi
@@ -502,17 +511,35 @@ fi
 echo ""
 echo "── Test 12: Direct binary + explicit NSISDIR ───────────────────"
 
-DIRECT_BIN=""
-if $IS_LINUX && [ -f "$BUNDLE_DIR/linux/makensis" ]; then
-    DIRECT_BIN="$BUNDLE_DIR/linux/makensis"
-    chmod +x "$DIRECT_BIN" 2>/dev/null || true
+if $IS_LINUX; then
+    for linux_arch in x64 arm64; do
+        linux_direct="$BUNDLE_DIR/linux/$linux_arch/makensis"
+        if [ ! -f "$linux_direct" ]; then
+            fail "Direct binary linux/$linux_arch + NSISDIR: binary not found"
+            continue
+        fi
+        chmod +x "$linux_direct" 2>/dev/null || true
+        cat > "$TMPDIR_TEST/direct-${linux_arch}.nsi" <<NSI
+Name "Direct"
+OutFile "direct-${linux_arch}-test.exe"
+InstallDir "\$TEMP\DirectTest"
+Section
+SectionEnd
+NSI
+        cd "$TMPDIR_TEST"
+        _direct_out=$(NSISDIR="$BUNDLE_DIR/windows" "$linux_direct" "direct-${linux_arch}.nsi" 2>&1 || true)
+        if [ -f "direct-${linux_arch}-test.exe" ]; then
+            pass "Direct binary linux/$linux_arch + NSISDIR: compiled successfully"
+        elif echo "$_direct_out" | grep -qi "exec format\|cannot execute"; then
+            skip "Direct binary linux/$linux_arch + NSISDIR: cross-arch (QEMU not available)"
+        else
+            fail "Direct binary linux/$linux_arch + NSISDIR: $_direct_out"
+        fi
+    done
 elif $IS_MAC; then
-    DIRECT_BIN="$BUNDLE_DIR/mac/$MAC_ARCH_DIR/makensis"
+    DIRECT_BIN="$BUNDLE_DIR/mac/$ARCH_DIR/makensis"
     [ -f "$DIRECT_BIN" ] || DIRECT_BIN="$BUNDLE_DIR/mac/makensis"
     chmod +x "$DIRECT_BIN" 2>/dev/null || true
-fi
-
-if [ -n "$DIRECT_BIN" ] && [ -f "$DIRECT_BIN" ]; then
     cat > "$TMPDIR_TEST/direct.nsi" <<'NSI'
 Name "Direct"
 OutFile "direct-test.exe"
@@ -523,9 +550,9 @@ NSI
     cd "$TMPDIR_TEST"
     if NSISDIR="$BUNDLE_DIR/windows" "$DIRECT_BIN" "direct.nsi" >/dev/null 2>&1 \
        && [ -f "direct-test.exe" ]; then
-        pass "Direct binary + NSISDIR: compiled successfully"
+        pass "Direct binary mac/$ARCH_DIR + NSISDIR: compiled successfully"
     else
-        fail "Direct binary + NSISDIR: binary returned non-zero or no output"
+        fail "Direct binary mac/$ARCH_DIR + NSISDIR: binary returned non-zero or no output"
     fi
 else
     skip "Direct binary + NSISDIR: no native binary for this platform (Windows)"


### PR DESCRIPTION
This pull request adds support for building and packaging an `arm64` (aarch64) Linux binary for `makensis` alongside the existing `x64` binary, improving platform compatibility for the NSIS package. The build scripts, documentation, and CI workflow have been updated to support and test these changes.