### PR TITLE
fix(nsis): copy `NSProcess.dll` to both Plugin directories and add to sanity test script

### DIFF
--- a/.changeset/gentle-ads-do.md
+++ b/.changeset/gentle-ads-do.md
@@ -1,0 +1,5 @@
+---
+"nsis": patch
+---
+
+fix(nsis): properly copy NSProcess.dll to both Plugin directories and add to sanity test script

--- a/.changeset/gentle-ads-do.md
+++ b/.changeset/gentle-ads-do.md
@@ -2,4 +2,4 @@
 "nsis": patch
 ---
 
-fix(nsis): properly copy NSProcess.dll to both Plugin directories and add to sanity test script
+fix(nsis): properly copy `NSProcess.dll` to both Plugin directories and add to sanity test script

--- a/.changeset/gentle-ads-do.md
+++ b/.changeset/gentle-ads-do.md
@@ -2,4 +2,4 @@
 "nsis": patch
 ---
 
-fix(nsis): properly copy `NSProcess.dll` to both Plugin directories and add to sanity test script
+fix(nsis): properly copy `nsProcess.dll`/`nsProcessW.dll` to both Plugin directories and add to sanity test script

--- a/packages/nsis/assets/nsis-combine.sh
+++ b/packages/nsis/assets/nsis-combine.sh
@@ -261,17 +261,17 @@ cat > "$BUILD_DIR/nsis-bundle/makensis.cmd" <<'EOF'
 @echo off
 setlocal ENABLEEXTENSIONS
 
-REM =============================================================
-REM NSIS Windows CMD Entrypoint
-REM =============================================================
-REM Delegates to makensis.ps1 via pwsh so that makensisw.exe
-REM (GUI subsystem) can be run hidden and auto-closed after compile.
-REM =============================================================
+set "SCRIPT_DIR=%~dp0"
+set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+set "NSISDIR=%SCRIPT_DIR%\windows"
+set "MAKENSIS_EXE=%NSISDIR%\makensis.exe"
 
-set SCRIPT_DIR=%~dp0
-set SCRIPT_DIR=%SCRIPT_DIR:~0,-1%
+if not exist "%MAKENSIS_EXE%" (
+    echo makensis.exe not found at: %MAKENSIS_EXE% 1>&2
+    exit /b 1
+)
 
-pwsh -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%\makensis.ps1" %*
+"%MAKENSIS_EXE%" %*
 exit /b %ERRORLEVEL%
 EOF
 

--- a/packages/nsis/assets/nsis-linux.sh
+++ b/packages/nsis/assets/nsis-linux.sh
@@ -67,7 +67,7 @@ echo "📝 Creating Dockerfile for Linux build..."
 DOCKERFILE="$OUT_DIR/Dockerfile.linux"
 
 cat > "$DOCKERFILE" <<'DOCKERFILE_END'
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS builder
 
 ARG NSIS_BRANCH
 ARG DEBIAN_FRONTEND=noninteractive
@@ -100,12 +100,12 @@ RUN scons \
     PREFIX=/build/install \
     install-compiler
 
-# The binary is now at /build/install/makensis
 RUN chmod +x /build/install/makensis
 
-# Create output directory
-RUN mkdir -p /output && \
-    cp /build/install/makensis /output/makensis
+# Export stage: scratch image contains only the binary so `type=local` output
+# is the binary alone rather than the full Ubuntu filesystem (~400 MB).
+FROM scratch
+COPY --from=builder /build/install/makensis /output/makensis
 DOCKERFILE_END
 
 # =============================================================================

--- a/packages/nsis/assets/nsis-test.sh
+++ b/packages/nsis/assets/nsis-test.sh
@@ -491,6 +491,7 @@ SilentInstall silent
 ; Each Plugin::Function call causes makensis to locate the DLL,
 ; read its PE export table, and embed it. Installer is never executed.
 Section "Main"
+  ; --- NSIS built-in plugins ---
   nsExec::Exec 'echo test'
   Pop $0
   Math::Script 'var x=1;'
@@ -516,13 +517,31 @@ Section "Main"
   NSISdl::download "http://localhost" "$TEMP\noop.tmp"
   nsProcess::_FindProcess "makensis.exe" $0
   Pop $0
+
+  ; --- Community plugins ---
+  INetC::get "http://localhost" "$TEMP\inetc.tmp" /end
+  Pop $0
+  StdUtils::GetRealOsName
+  Pop $0
+  SpiderBanner::Show /NOUNLOAD "Smoke Test"
+  Pop $0
+  EmbedHTML::GetIEVersion
+  Pop $0
+  WinShell::SetLnkAUMI "$TEMP\test.lnk" "App.ID"
+  Pop $0
+  nsis7z::Extract "$EXEPATH" "$TEMP\7ztest"
+  Pop $0
+  nsisunz::Unzip "$EXEPATH" "$TEMP\unztest"
+  Pop $0
+  UAC::_ 0
+  Pop $0
 SectionEnd
 NSI
 
 cd "$TMPDIR_TEST"
 SMOKE_OUT=$(run_wrapper "$WRAPPER" "plugin-smoke.nsi" 2>&1 || true)
 if [ -f "plugin-smoke.exe" ]; then
-    pass "Plugin smoke compile: all 17 plugin DLLs loaded and embedded"
+    pass "Plugin smoke compile: all 25 plugin DLLs loaded and embedded"
 else
     fail "Plugin smoke compile: failed — $SMOKE_OUT"
 fi

--- a/packages/nsis/assets/nsis-test.sh
+++ b/packages/nsis/assets/nsis-test.sh
@@ -288,19 +288,27 @@ BASE_DLLS=(
     Banner.dll
     BgImage.dll
     Dialer.dll
+    EmbedHTML.dll
+    INetC.dll
     InstallOptions.dll
     LangDLL.dll
     Math.dll
     NSISdl.dll
+    SpiderBanner.dll
     Splash.dll
     StartMenu.dll
+    StdUtils.dll
     System.dll
     TypeLib.dll
+    UAC.dll
     UserInfo.dll
     VPatch.dll
+    WinShell.dll
+    nsis7z.dll
     nsDialogs.dll
     nsExec.dll
     nsProcess.dll
+    nsisunz.dll
 )
 
 for arch_dir in x86-unicode x86-ansi; do
@@ -309,6 +317,10 @@ for arch_dir in x86-unicode x86-ansi; do
             "Plugins/$arch_dir/$dll present"
     done
 done
+
+# nsProcessW.dll is the Unicode variant — only present in x86-unicode under its W-suffixed name
+assert_file "$BUNDLE_DIR/windows/Plugins/x86-unicode/nsProcessW.dll" \
+    "Plugins/x86-unicode/nsProcessW.dll present"
 
 # Validate each DLL is a genuine Windows PE (MZ magic bytes)
 for arch_dir in x86-unicode x86-ansi; do
@@ -326,6 +338,14 @@ for arch_dir in x86-unicode x86-ansi; do
         fi
     done
 done
+_nsprocessw="$BUNDLE_DIR/windows/Plugins/x86-unicode/nsProcessW.dll"
+if [ -f "$_nsprocessw" ]; then
+    MZ_DLL=$(od -N 2 -A n -t x1 "$_nsprocessw" 2>/dev/null | tr -d ' \n')
+    [ "$MZ_DLL" = "4d5a" ] && pass "Plugins/x86-unicode/nsProcessW.dll valid MZ header" \
+                             || fail "Plugins/x86-unicode/nsProcessW.dll invalid or missing MZ header"
+else
+    skip "Plugins/x86-unicode/nsProcessW.dll not found (existence checked above)"
+fi
 
 # =============================================================================
 # Set up the wrapper for compile tests 7-15
@@ -502,7 +522,7 @@ NSI
 cd "$TMPDIR_TEST"
 SMOKE_OUT=$(run_wrapper "$WRAPPER" "plugin-smoke.nsi" 2>&1 || true)
 if [ -f "plugin-smoke.exe" ]; then
-    pass "Plugin smoke compile: all 16 plugin DLLs loaded and embedded"
+    pass "Plugin smoke compile: all 17 plugin DLLs loaded and embedded"
 else
     fail "Plugin smoke compile: failed — $SMOKE_OUT"
 fi

--- a/packages/nsis/assets/nsis-test.sh
+++ b/packages/nsis/assets/nsis-test.sh
@@ -517,6 +517,8 @@ Section "Main"
   NSISdl::download "http://localhost" "$TEMP\noop.tmp"
   nsProcess::_FindProcess "makensis.exe" $0
   Pop $0
+  nsProcessW::_FindProcess "makensis.exe" $0
+  Pop $0
 
   ; --- Community plugins ---
   INetC::get "http://localhost" "$TEMP\inetc.tmp" /end
@@ -541,7 +543,7 @@ NSI
 cd "$TMPDIR_TEST"
 SMOKE_OUT=$(run_wrapper "$WRAPPER" "plugin-smoke.nsi" 2>&1 || true)
 if [ -f "plugin-smoke.exe" ]; then
-    pass "Plugin smoke compile: all 25 plugin DLLs loaded and embedded"
+    pass "Plugin smoke compile: all 26 plugin DLLs loaded and embedded"
 else
     fail "Plugin smoke compile: failed — $SMOKE_OUT"
 fi

--- a/packages/nsis/assets/nsis-test.sh
+++ b/packages/nsis/assets/nsis-test.sh
@@ -300,6 +300,7 @@ BASE_DLLS=(
     VPatch.dll
     nsDialogs.dll
     nsExec.dll
+    nsProcess.dll
 )
 
 for arch_dir in x86-unicode x86-ansi; do
@@ -493,6 +494,8 @@ Section "Main"
   LangDLL::LangDialog "Smoke Test" "" "English" "English"
   Dialer::AttemptConnect
   NSISdl::download "http://localhost" "$TEMP\noop.tmp"
+  nsProcess::_FindProcess "makensis.exe" $0
+  Pop $0
 SectionEnd
 NSI
 

--- a/packages/nsis/assets/nsis-windows.sh
+++ b/packages/nsis/assets/nsis-windows.sh
@@ -434,7 +434,10 @@ for plugin_zip in "$PLUGINS_DIR"/*.zip; do
                 elif echo "$plugin_name" | grep -qiE 'NSISunzU'; then
                     cp "$dll_file" "$BUNDLE_DIR/windows/Plugins/x86-unicode/" 2>/dev/null || true
                 else
+                    # No architecture indicator: copy to both so the plugin is
+                    # available for both ANSI and Unicode compilations.
                     cp "$dll_file" "$BUNDLE_DIR/windows/Plugins/x86-ansi/" 2>/dev/null || true
+                    cp "$dll_file" "$BUNDLE_DIR/windows/Plugins/x86-unicode/" 2>/dev/null || true
                 fi
             fi
         done

--- a/packages/nsis/assets/nsis-windows.sh
+++ b/packages/nsis/assets/nsis-windows.sh
@@ -431,6 +431,12 @@ for plugin_zip in "$PLUGINS_DIR"/*.zip; do
                 # Filename-based heuristics
                 if echo "$dll_basename" | grep -qE 'W\.dll$|Unicode|unicode'; then
                     cp "$dll_file" "$BUNDLE_DIR/windows/Plugins/x86-unicode/" 2>/dev/null || true
+                    # Strip the W suffix so NSIS can find the DLL via PluginName::Function syntax
+                    # (e.g. nsProcessW.dll → nsProcess.dll so nsProcess::_FindProcess works)
+                    if echo "$dll_basename" | grep -qE 'W\.dll$'; then
+                        _base="${dll_basename%W.dll}.dll"
+                        cp "$dll_file" "$BUNDLE_DIR/windows/Plugins/x86-unicode/$_base" 2>/dev/null || true
+                    fi
                 elif echo "$plugin_name" | grep -qiE 'NSISunzU'; then
                     cp "$dll_file" "$BUNDLE_DIR/windows/Plugins/x86-unicode/" 2>/dev/null || true
                 else

--- a/packages/nsis/assets/nsis-windows.sh
+++ b/packages/nsis/assets/nsis-windows.sh
@@ -440,10 +440,16 @@ for plugin_zip in "$PLUGINS_DIR"/*.zip; do
                 elif echo "$plugin_name" | grep -qiE 'NSISunzU'; then
                     cp "$dll_file" "$BUNDLE_DIR/windows/Plugins/x86-unicode/" 2>/dev/null || true
                 else
-                    # No architecture indicator: copy to both so the plugin is
-                    # available for both ANSI and Unicode compilations.
+                    # No architecture indicator: copy to x86-ansi unconditionally.
+                    # Only copy to x86-unicode when no paired *W.dll exists in this
+                    # plugin's directory — if one does exist, the W-variant will be
+                    # installed to x86-unicode (and aliased without the W suffix), so
+                    # copying the ANSI binary there too would overwrite that alias.
                     cp "$dll_file" "$BUNDLE_DIR/windows/Plugins/x86-ansi/" 2>/dev/null || true
-                    cp "$dll_file" "$BUNDLE_DIR/windows/Plugins/x86-unicode/" 2>/dev/null || true
+                    _wvariant="${dll_basename%.dll}W.dll"
+                    if ! find "$extract_dir" -name "$_wvariant" -type f 2>/dev/null | grep -q .; then
+                        cp "$dll_file" "$BUNDLE_DIR/windows/Plugins/x86-unicode/" 2>/dev/null || true
+                    fi
                 fi
             fi
         done


### PR DESCRIPTION
This pull request addresses issues with the handling of NSIS plugin DLLs, especially `nsProcess.dll` and `nsProcessW.dll`, and improves the build and test scripts for both Linux and Windows. The main focus is ensuring all required plugin DLLs are correctly copied to their respective directories and validated, and that the test suite covers these plugins more thoroughly.
* Ensured both `nsProcess.dll` and `nsProcessW.dll` are properly copied to the appropriate plugin directories (`x86-ansi` and `x86-unicode`), including aliasing the Unicode variant without the `W` suffix for compatibility.
* Added and validated more community and built-in plugins in the test script, expanding the smoke test to cover 26 DLLs, including new plugins like `INetC.dll`, `SpiderBanner.dll`, `StdUtils.dll`, `UAC.dll`, and others. 
* Refactored the Linux Dockerfile to use a multi-stage build, producing a minimal output image containing only the `makensis` binary.
* Simplified the Windows entrypoint script to call `makensis.exe` directly, improving reliability and removing unnecessary PowerShell delegation.
