### PR TITLE
chore(deploy): fix publish script and force redeploy of previous release

### DIFF
--- a/.changeset/forty-candles-bet.md
+++ b/.changeset/forty-candles-bet.md
@@ -1,0 +1,7 @@
+---
+"win-codesign": patch
+"dmg-builder": patch
+"nsis": patch
+---
+
+chore(deploy): redeploying due to failed attest CJS->ESM module update

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,9 @@ jobs:
         run: |
           pnpm i --frozen-lockfile
 
+      - name: Validate release script imports
+        run: node scripts/changeset-publish.js --dry-run
+
       - name: Detect packages to release
         id: set
         run: sh ./scripts/detect-packages.sh

--- a/scripts/changeset-publish.js
+++ b/scripts/changeset-publish.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const { attestProvenance } = require("@actions/attest");
 const { execSync } = require("child_process");
 const fs = require("fs");
 const { Octokit } = require("@octokit/rest");
@@ -10,8 +9,10 @@ const mime = require("mime-types");
 // We do this manually because we want specific/scoped assets to be uploaded to a corresponding SCOPED releases.
 // e.g. nsis artifacts should be uploaded to the nsis release, not in a zstd release.
 // JSON format: https://github.com/changesets/action?tab=readme-ov-file#outputs
+const isDryRun = process.argv.includes("--dry-run");
+
 const publishedPackages = process.env.PUBLISHED_PACKAGES;
-if (!publishedPackages) {
+if (!publishedPackages && !isDryRun) {
   console.error("PUBLISHED_PACKAGES environment variable is not set. See script for documentation.");
   process.exit(1);
 }
@@ -84,6 +85,13 @@ async function atomicReleaseWithStreams({ owner, repo, tag, name, body, assets, 
 }
 
 async function run() {
+  const { attestProvenance } = await import("@actions/attest");
+
+  if (isDryRun) {
+    console.log("Dry run: all imports resolved successfully.");
+    return;
+  }
+
   const releases = JSON.parse(publishedPackages);
 
   console.log("Release candidates:", releases);


### PR DESCRIPTION
`scripts/changeset-publish.js`

Added `const isDryRun = process.argv.includes("--dry-run")` => `PUBLISHED_PACKAGES` check is skipped in dry-run mode
After `await import("@actions/attest")` succeeds, dry-run exits with a success message — no file I/O, no API calls, no credentials needed

`.github/workflows/build.yaml`
Added `Validate release script imports` step in the detect job, immediately after pnpm install
Runs on every PR and every push to master — the same Node 22 + frozen-lockfile environment that the release job uses, so any future ESM/CJS mismatch from a dep bump will fail here rather than in the release workflow