### PR TITLE
fix: correct the concurrency group for wine builds to allow releases to proceed without interruption/cancelaation

### DIFF
--- a/.github/workflows/build-wine.yaml
+++ b/.github/workflows/build-wine.yaml
@@ -4,8 +4,8 @@ on:
   workflow_call:
   workflow_dispatch:
 
-concurrency: 
-  group: ${{ github.head_ref }}
+concurrency:
+  group: wine-${{ github.ref }}-${{ github.run_id }}
   cancel-in-progress: true # for the love of all that is holy, cancel in progress runs on new pushes. linux builds take forever
     
 jobs:


### PR DESCRIPTION
### Summary

- **fix(wine CI)**: Correct the `build-wine.yaml` concurrency group — the previous `group: ${{ github.head_ref }}` evaluated to `""` on master pushes, causing the two concurrent runs triggered by every push (`Build artifacts` + `Release`) to mutually cancel each other's wine jobs. Changed to `wine-${{ github.ref }}-${{ github.run_id }}` so each run is isolated. Root cause of all recent release failures for wine/nsis/wix

Failing run: https://github.com/electron-userland/electron-builder-binaries/actions/runs/26765356617/job/78893617185