### PR TITLE
fix: Add `combine` job for `wine` to properly merge artifacts under common `./out` folder

### DIFF
--- a/.github/workflows/build-wine.yaml
+++ b/.github/workflows/build-wine.yaml
@@ -47,3 +47,29 @@ jobs:
           path: packages/wine/out/*.tar.xz
           if-no-files-found: error
           retention-days: 1
+
+  combine:
+    runs-on: ubuntu-latest
+    needs: [mac, linux]
+    steps:
+      - name: Download wine artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          pattern: wine-*
+          merge-multiple: true
+          path: out/
+
+      - name: Upload combined wine artifact
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        with:
+          name: wine
+          path: out/
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Delete interim artifacts
+        uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b
+        with:
+          name: |
+            wine-macos
+            wine-linux


### PR DESCRIPTION
Add `combine` job that merges `wine-macos` and `wine-linux` artifacts into a single `wine` artifact so `changeset-version.js` can find `artifacts-staging/wine` by package name