### PR TITLE
fix(dmg-builder): CJK license encoding in DMG builds

### DIFF
--- a/.changeset/fix-dmgbuild-cjk-codecs.md
+++ b/.changeset/fix-dmgbuild-cjk-codecs.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": patch
+---
+
+fix(dmg-builder): CJK license encoding in DMG builds: re-bundle CJK codec extensions, correct the `multibyte_encoding` → `multibyte` key-name bug in `licensing.py`, and add UTF-8 fallbacks so a missing codec never aborts the build.

--- a/packages/dmg-builder/assets/build-python-runtime.sh
+++ b/packages/dmg-builder/assets/build-python-runtime.sh
@@ -229,7 +229,7 @@ for mod in asyncio concurrent curses dbm email html http idlelib \
     test_dmgbuild
 done
 
-for ext in _asyncio _bz2 _codecs_{cn,hk,iso2022,jp,kr,tw} _crypt \
+for ext in _asyncio _bz2 _crypt \
     _curses{,_panel} _{dbm,gdbm} _lzma _multiprocessing _posixshmem \
     _queue _sqlite3 _tkinter audioop nis ossaudiodev readline \
     spwd syslog termios xxlimited; do
@@ -517,6 +517,38 @@ if failures:
 
 print("✓ All dmgbuild patches verified in bundled core.py")
 PATCH_VERIFY
+
+# Test 6b: CJK codec and licensing.py patch availability
+run_arch "$DIR_TO_ARCHIVE/python/bin/python3" - <<'CJK_TEST'
+import sys, inspect
+import dmgbuild.licensing as licensing
+
+# CJK codecs must be present (kept in bundle)
+for codec, text in [("shift_jis", "テスト"), ("ksx1001", "테스트"), ("gb2312", "测试"), ("big5", "測試")]:
+    try:
+        text.encode(codec)
+    except LookupError as e:
+        print(f"❌ Missing CJK codec: {e}", file=sys.stderr)
+        sys.exit(1)
+print("  ✓ CJK codecs (shift_jis, ksx1001, gb2312, big5) available")
+
+# licensing.py patches must be present
+src = inspect.getsource(licensing)
+failures = []
+if 'language_info.get("multibyte_encoding"' in src:
+    failures.append("multibyte key-name fix not applied: still uses 'multibyte_encoding'")
+if '"multibyte", False)' not in src and "'multibyte', False)" not in src:
+    failures.append("multibyte key-name fix not applied: 'multibyte' key not found")
+if src.count("except LookupError") < 2:
+    failures.append("UTF-8 fallback patches not applied: expected at least 2 'except LookupError' blocks")
+
+if failures:
+    for f in failures:
+        print(f"❌ {f}", file=sys.stderr)
+    sys.exit(1)
+
+print("  ✓ licensing.py patches verified")
+CJK_TEST
 
 # Test 7: Size formula correctness
 run_arch "$DIR_TO_ARCHIVE/python/bin/python3" - <<'SIZE_TEST'

--- a/packages/dmg-builder/assets/patch-dmgbuild.py
+++ b/packages/dmg-builder/assets/patch-dmgbuild.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """
-Apply targeted patches to the installed dmgbuild core module.
+Apply targeted patches to the installed dmgbuild core module and licensing module.
 
 Run this after `pip install dmgbuild` and before archiving the bundle.
 Exits non-zero if any expected pattern is not found — the build will then
 fail loudly rather than silently ship an unpatched bundle.
 """
 
+import os
 import sys
 
 
@@ -62,10 +63,84 @@ def apply_patches(path: str) -> None:
     with open(path, "w", encoding="utf-8") as fh:
         fh.write(src)
 
-    print(f"patch-dmgbuild: all patches applied to {path}")
+    print(f"patch-dmgbuild: all core patches applied to {path}")
+
+
+def apply_patches_licensing(path: str) -> None:
+    with open(path, "r", encoding="utf-8") as fh:
+        src = fh.read()
+
+    patches = [
+        (
+            # Fix L1: The language_info_map uses "multibyte": True for CJK
+            # entries, but the code reads "multibyte_encoding" — a key that
+            # never exists — so the LPic "2-byte language" field is always 0
+            # for CJK languages.  This corrects the key name so the field is
+            # set properly.
+            'multibyte_encoding = language_info.get("multibyte_encoding", False)',
+            'multibyte_encoding = language_info.get("multibyte", False)',
+            "licensing: fix multibyte key name (multibyte_encoding → multibyte)",
+        ),
+        (
+            # Fix L2: When the bundled Python does not include a CJK codec
+            # (e.g. shift_jis for Japanese), license_data.encode() raises
+            # LookupError and aborts the entire DMG build.  Fall back to
+            # UTF-8 so the license body is still embedded; modern macOS SLA
+            # dialogs render UTF-8 TEXT resources correctly.
+            "            licenseDataFormat = \"TEXT\"\n"
+            "            license_data = license_data.encode(language_encoding)",
+            "            licenseDataFormat = \"TEXT\"\n"
+            "            try:\n"
+            "                license_data = license_data.encode(language_encoding)\n"
+            "            except LookupError:\n"
+            "                license_data = license_data.encode(\"utf-8\")",
+            "licensing: UTF-8 fallback for license body when target codec is unavailable",
+        ),
+        (
+            # Fix L3: Same LookupError problem for button-label encoding.
+            # Default buttons for Japanese/Korean/Chinese contain Unicode text
+            # that must be encoded into the STR# resource.  Fall back to UTF-8
+            # so button labels are still present rather than crashing the build.
+            #
+            # Additional care: some default messages (e.g. Japanese at 90 chars)
+            # exceed 255 bytes when encoded as UTF-8 (3 bytes/char × 90 = 270).
+            # The STR# length prefix is a single byte, so anything > 255 raises
+            # OverflowError on the next line.  We truncate to ≤255 bytes while
+            # preserving valid UTF-8 by round-tripping through decode(errors=
+            # 'ignore') before the final encode.
+            "        buttons = [b.encode(language_encoding) for b in buttons]",
+            "        try:\n"
+            "            buttons = [b.encode(language_encoding) for b in buttons]\n"
+            "        except LookupError:\n"
+            "            buttons = [\n"
+            "                b.encode(\"utf-8\")[:255].decode(\"utf-8\", errors=\"ignore\").encode(\"utf-8\")\n"
+            "                for b in buttons\n"
+            "            ]",
+            "licensing: UTF-8 fallback for button encoding with safe 255-byte truncation",
+        ),
+    ]
+
+    for old, new, label in patches:
+        if old not in src:
+            sys.exit(
+                f"patch-dmgbuild: FAILED to find pattern for patch '{label}'.\n"
+                f"The upstream dmgbuild licensing.py may have changed; review and update the patch."
+            )
+        src = src.replace(old, new, 1)
+        print(f"  ✓ Applied patch: {label}")
+
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(src)
+
+    print(f"patch-dmgbuild: all licensing patches applied to {path}")
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         sys.exit(f"Usage: {sys.argv[0]} <path/to/dmgbuild/core.py>")
-    apply_patches(sys.argv[1])
+
+    core_path = sys.argv[1]
+    apply_patches(core_path)
+
+    licensing_path = os.path.join(os.path.dirname(core_path), "licensing.py")
+    apply_patches_licensing(licensing_path)

--- a/packages/dmg-builder/assets/tests/test_dmg_core.py
+++ b/packages/dmg-builder/assets/tests/test_dmg_core.py
@@ -304,10 +304,23 @@ class TestPatchScript(unittest.TestCase):
             fh.write(content)
         return path
 
+    def _make_fake_licensing(self, content):
+        path = os.path.join(self._tmp, "licensing.py")
+        with open(path, "w") as fh:
+            fh.write(content)
+        return path
+
     def test_patches_applied_correctly(self):
         fake_core = self._make_fake_core(
             'total_size = str(max(total_size / 1000, 1024)) + "K"\n'
             'subprocess.call(["/usr/bin/ditto", f, f_in_image])\n'
+        )
+        # licensing.py must live next to core.py for auto-discovery
+        fake_licensing = self._make_fake_licensing(
+            'multibyte_encoding = language_info.get("multibyte_encoding", False)\n'
+            '            licenseDataFormat = "TEXT"\n'
+            '            license_data = license_data.encode(language_encoding)\n'
+            '        buttons = [b.encode(language_encoding) for b in buttons]\n'
         )
         result = subprocess.run(
             [sys.executable, self._patch_script_path(), fake_core],
@@ -315,12 +328,20 @@ class TestPatchScript(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
+
         with open(fake_core) as fh:
-            patched = fh.read()
-        self.assertIn('total_size * 1.2 / 1024', patched)
-        self.assertIn('subprocess.check_call(["/usr/bin/ditto"', patched)
-        self.assertNotIn("total_size / 1000", patched)
-        self.assertNotIn('subprocess.call(["/usr/bin/ditto"', patched)
+            patched_core = fh.read()
+        self.assertIn('total_size * 1.2 / 1024', patched_core)
+        self.assertIn('subprocess.check_call(["/usr/bin/ditto"', patched_core)
+        self.assertNotIn("total_size / 1000", patched_core)
+        self.assertNotIn('subprocess.call(["/usr/bin/ditto"', patched_core)
+
+        with open(fake_licensing) as fh:
+            patched_licensing = fh.read()
+        self.assertNotIn('"multibyte_encoding"', patched_licensing)
+        self.assertIn('"multibyte", False)', patched_licensing)
+        self.assertGreaterEqual(patched_licensing.count("except LookupError"), 2)
+        self.assertIn('decode("utf-8", errors="ignore")', patched_licensing)
 
     def test_script_fails_when_pattern_missing(self):
         """Patch script must exit non-zero when expected patterns are absent."""
@@ -378,6 +399,120 @@ class TestDMGSizeAdequacy(unittest.TestCase):
         margin = volume_bytes - app_size
         self.assertGreater(margin, 300 * 1024 * 1024,
                            f"Margin {margin // (1024*1024)} MB is too small")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: CJK codec availability
+# ---------------------------------------------------------------------------
+
+class TestCJKCodecAvailability(unittest.TestCase):
+    """The bundle must include CJK codec extension modules so that dmgbuild's
+    licensing.py can encode Japanese, Korean, and Chinese license text."""
+
+    def test_shift_jis_codec_available(self):
+        """shift_jis must be available for Japanese license encoding."""
+        try:
+            "テスト".encode("shift_jis")
+        except LookupError as e:
+            self.fail(f"shift_jis codec unavailable: {e}")
+
+    def test_ksx1001_codec_available(self):
+        """ksx1001 must be available for Korean license encoding."""
+        try:
+            "테스트".encode("ksx1001")
+        except LookupError as e:
+            self.fail(f"ksx1001 codec unavailable: {e}")
+
+    def test_gb2312_codec_available(self):
+        """gb2312 must be available for Simplified Chinese license encoding."""
+        try:
+            "测试".encode("gb2312")
+        except LookupError as e:
+            self.fail(f"gb2312 codec unavailable: {e}")
+
+    def test_big5_codec_available(self):
+        """big5 must be available for Traditional Chinese license encoding."""
+        try:
+            "測試".encode("big5")
+        except LookupError as e:
+            self.fail(f"big5 codec unavailable: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: licensing.py patches
+# ---------------------------------------------------------------------------
+
+class TestLicensingPatches(unittest.TestCase):
+    """Verify that patch-dmgbuild.py applied all three patches to licensing.py."""
+
+    @classmethod
+    def setUpClass(cls):
+        import dmgbuild.licensing as licensing
+        import inspect
+        cls._licensing_src = inspect.getsource(licensing)
+        cls._licensing = licensing
+
+    def test_multibyte_key_fixed(self):
+        """language_info_map uses 'multibyte', not 'multibyte_encoding' — the
+        LPic field must read the correct key."""
+        self.assertNotIn(
+            'language_info.get("multibyte_encoding"',
+            self._licensing_src,
+            "multibyte key-name fix not applied: 'multibyte_encoding' still present",
+        )
+        self.assertTrue(
+            '"multibyte", False)' in self._licensing_src
+            or "'multibyte', False)" in self._licensing_src,
+            "multibyte key-name fix not applied: 'multibyte' key not found in source",
+        )
+
+    def test_utf8_fallback_license_body_present(self):
+        """UTF-8 fallback patch for license body encoding must be present."""
+        self.assertGreaterEqual(
+            self._licensing_src.count("except LookupError"),
+            2,
+            "Expected at least 2 'except LookupError' blocks in licensing.py (body + buttons)",
+        )
+
+    def test_utf8_fallback_buttons_present(self):
+        """UTF-8 fallback for button encoding must be present in source."""
+        # We specifically check that the fallback appears near the buttons encode
+        self.assertIn(
+            'encode("utf-8")',
+            self._licensing_src,
+            "UTF-8 fallback encode not found in licensing.py",
+        )
+
+    def _make_temp_license_file(self, content: str, suffix: str = ".txt") -> str:
+        import tempfile
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        return path
+
+    def test_build_license_japanese(self):
+        """build_license must succeed for ja_JP — no LookupError for shift_jis."""
+        tmp = self._make_temp_license_file("こんにちは\nテスト ライセンス文書")
+        try:
+            result = self._licensing.build_license({"licenses": {"ja_JP": tmp}})
+            self.assertIn("STR#", result)
+            self.assertIn("LPic", result)
+        except LookupError as e:
+            self.fail(f"build_license raised LookupError for ja_JP: {e}")
+        finally:
+            os.unlink(tmp)
+
+    def test_build_license_korean(self):
+        """build_license must succeed for ko_KR — no LookupError for ksx1001."""
+        tmp = self._make_temp_license_file("안녕하세요\n테스트 라이센스 문서")
+        try:
+            result = self._licensing.build_license({"licenses": {"ko_KR": tmp}})
+            self.assertIn("STR#", result)
+            self.assertIn("LPic", result)
+        except LookupError as e:
+            self.fail(f"build_license raised LookupError for ko_KR: {e}")
+        finally:
+            os.unlink(tmp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

- **fix(dmg-builder)**: Re-enable CJK codec extension modules in the bundled Python runtime — `_codecs_{cn,hk,iso2022,jp,kr,tw}` were previously stripped, causing `dmgbuild` to silently skip CJK license encoding or crash with `LookupError` when building DMGs with Japanese/Korean/Chinese license agreements.

- **fix(dmg-builder)**: Extend `patch-dmgbuild.py` to also patch `dmgbuild/licensing.py` (auto-discovered as a sibling of `core.py`) with three targeted fixes:
  - **L1 — wrong key name**: `language_info.get("multibyte_encoding", False)` → `language_info.get("multibyte", False)`. The `language_info_map` uses the key `"multibyte"`, so the LPic "2-byte language" field was always `0` for every CJK language, producing malformed SLA resources.
  - **L2 — UTF-8 fallback for license body**: Wraps `license_data.encode(language_encoding)` in a `try/except LookupError` that falls back to UTF-8, so a missing codec no longer aborts the build. macOS renders UTF-8 `TEXT` resources correctly.
  - **L3 — UTF-8 fallback for button labels (with safe truncation)**: Same treatment for `buttons = [b.encode(language_encoding) …]`. Adds a ≤255-byte safe truncation via `decode("utf-8", errors="ignore")` before the final encode, because some default Japanese button strings (≥90 chars × 3 bytes = >255) would otherwise overflow the STR# length-prefix byte.

- **test(dmg-builder)**: Comprehensive test coverage added to [`test_dmg_core.py`](packages/dmg-builder/assets/tests/test_dmg_core.py):
  - `TestPatchScript.test_patches_applied_correctly` — now creates a fake `licensing.py` alongside the fake `core.py` and asserts all three licensing patches were applied.
  - `TestCJKCodecAvailability` — four unit tests confirming `shift_jis`, `ksx1001`, `gb2312`, and `big5` codecs are importable in the bundle.
  - `TestLicensingPatches` — inspects the patched `dmgbuild.licensing` source to verify key-name and LookupError-fallback patches; calls `build_license()` end-to-end for `ja_JP` and `ko_KR` to confirm no `LookupError` is raised.

- **test(build-python-runtime.sh)**: Added **Test 6b** — a runtime verification step that runs inside the bundled Python after archiving, confirming CJK codecs encode correctly and that all three licensing.py patches are present in the installed module.

### Changed Files

| File | Change |
|------|--------|
| [packages/dmg-builder/assets/build-python-runtime.sh](packages/dmg-builder/assets/build-python-runtime.sh) | Remove `_codecs_{cn,hk,iso2022,jp,kr,tw}` from the stripped-extension list; add Test 6b |
| [packages/dmg-builder/assets/patch-dmgbuild.py](packages/dmg-builder/assets/patch-dmgbuild.py) | Add `apply_patches_licensing()` with L1/L2/L3 patches; auto-discover `licensing.py` sibling |
| [packages/dmg-builder/assets/tests/test_dmg_core.py](packages/dmg-builder/assets/tests/test_dmg_core.py) | Update `TestPatchScript`; add `TestCJKCodecAvailability` and `TestLicensingPatches` |

### Design Notes

**Why keep the codecs rather than only patching the UTF-8 fallback?**
The UTF-8 fallback (L2/L3) is a safety net, not the primary fix. The real fix is having the codec present so the SLA dialog renders in the correct encoding for the user's language. A Japanese user receiving a UTF-8-encoded `TEXT` resource may see garbled text depending on their macOS locale; Shift-JIS is the authoritative encoding for the dmgbuild `ja_JP` language entry. The fallback prevents build failures on edge cases (e.g. an unusual `language_info_map` entry pointing to an obscure codec), but correct behavior requires the codecs bundled.

**Why L1 matters independently of L2/L3:**
Even if all codecs are present, without the L1 key-name fix the LPic resource has an incorrect `two_byte_language` flag for every CJK language. Some versions of macOS use this field to select the right string encoding when displaying the SLA.
