### PR TITLE
feat(squirrel.windows): bundle nuget.exe and 7z from GH runner into vendor directory

### DIFF
--- a/.changeset/bundle-nuget-and-7zip.md
+++ b/.changeset/bundle-nuget-and-7zip.md
@@ -1,0 +1,5 @@
+---
+"squirrel.windows": minor
+---
+
+feat(squirrel.windows): bundle nuget.exe and 7-Zip binaries into vendor directory

--- a/.github/workflows/build-squirrel.yaml
+++ b/.github/workflows/build-squirrel.yaml
@@ -12,6 +12,10 @@ jobs:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       NUGET_XMLDOC_MODE: skip
+      # Squirrel.Windows 2.0.1 uses GitVersionTask which emits ##[set-env] commands.
+      # That syntax was disabled in runners after Oct 2020; this re-enables it for
+      # this isolated build job so the version-stamping step doesn't fail the run.
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Enable Git long paths
         run: git config --system core.longpaths true

--- a/.github/workflows/build-squirrel.yaml
+++ b/.github/workflows/build-squirrel.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with: { submodules: true }
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@4fbf5680f8493fb5ec8a01d9448b5a7efa830f25
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57
       - name: Build Squirrel.Windows
         run: .\packages\squirrel.windows\build.ps1
         shell: pwsh

--- a/.github/workflows/build-squirrel.yaml
+++ b/.github/workflows/build-squirrel.yaml
@@ -6,7 +6,7 @@ on:
     
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       DOTNET_NOLOGO: true
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/packages/squirrel.windows/build.ps1
+++ b/packages/squirrel.windows/build.ps1
@@ -34,9 +34,18 @@ if ($PatchPath -and (Test-Path $PatchPath) -and (Get-Item $PatchPath).PSIsContai
 
 # --- Run the official build
 Write-Host "`n🏗️ Running build steps..."
+
 nuget restore .\Squirrel.sln
-msbuild -Restore .\Squirrel.sln -p:Configuration=Release -v:m -m -nr:false -bl:.\build\logs\build.binlog
+if ($LASTEXITCODE -ne 0) { Write-Error "nuget restore failed (exit $LASTEXITCODE)"; exit $LASTEXITCODE }
+
+# PlatformToolset=v143 retargets the C++ projects (Setup, StubExecutable, WriteZipToSetup)
+# to the VS 2022 toolchain. windows-2022 runners ship v143 but not the v141 (VS 2017)
+# toolset that Squirrel.Windows 2.0.1's vcxproj files request by default.
+msbuild -Restore .\Squirrel.sln -p:Configuration=Release -p:PlatformToolset=v143 -v:m -m -nr:false -bl:.\build\logs\build.binlog
+if ($LASTEXITCODE -ne 0) { Write-Error "msbuild failed (exit $LASTEXITCODE)"; exit $LASTEXITCODE }
+
 nuget pack .\src\Squirrel.nuspec -OutputDirectory .\build\artifacts
+if ($LASTEXITCODE -ne 0) { Write-Error "nuget pack failed (exit $LASTEXITCODE)"; exit $LASTEXITCODE }
 
 # --- Layout electron-winstaller vendor folder
 $vendorDir = Join-Path $outputDir "electron-winstaller\vendor"

--- a/packages/squirrel.windows/build.ps1
+++ b/packages/squirrel.windows/build.ps1
@@ -113,12 +113,21 @@ foreach ($f in @("7z.exe", "7z.dll")) {
 # x64 arch-specific copies (mirrors what electron-winstaller's npm postinstall script does)
 Copy-Item "$7zDir\7z.exe" (Join-Path $vendorDir "7z-x64.exe") -Force
 Copy-Item "$7zDir\7z.dll" (Join-Path $vendorDir "7z-x64.dll") -Force
-Write-Host "  7z x64 binaries bundled."
+# Bundle 7-Zip license files alongside the binaries
+$7zLicenseSrc = @("License.txt", "license.txt") | ForEach-Object { Join-Path $7zDir $_ } | Where-Object { Test-Path $_ } | Select-Object -First 1
+if ($7zLicenseSrc) {
+    Copy-Item $7zLicenseSrc (Join-Path $vendorDir "7z-LICENSE.txt") -Force
+    Write-Host "  7z x64 binaries and license bundled."
+} else {
+    Write-Warning "7-Zip License.txt not found at $7zDir — skipping."
+    Write-Host "  7z x64 binaries bundled (no license file found)."
+}
 
-# --- LICENSE
-$licenseSrc = Join-Path $repoRoot "LICENSE"
-if (-not (Test-Path $licenseSrc)) {
-    Write-Error "LICENSE not found in cloned repo at $licenseSrc"
+# --- LICENSE (Squirrel.Windows)
+# The Squirrel.Windows repo uses COPYING (not LICENSE) as its license file name.
+$licenseSrc = @("COPYING", "LICENSE", "LICENSE.md") | ForEach-Object { Join-Path $repoRoot $_ } | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $licenseSrc) {
+    Write-Error "LICENSE/COPYING not found in cloned repo at $repoRoot"
     exit 1
 }
 Copy-Item $licenseSrc (Join-Path $vendorDir "LICENSE") -Force

--- a/packages/squirrel.windows/build.ps1
+++ b/packages/squirrel.windows/build.ps1
@@ -6,16 +6,16 @@ param (
 $ErrorActionPreference = "Stop"
 
 # --- Configuration
-$repoRoot = "C:\s\Squirrel.Windows"
-$artifactDir = Join-Path $PSScriptRoot "out\squirrel.windows"
-$outputDir = Join-Path $repoRoot "build\artifacts"
-$archivePath = Join-Path $artifactDir "squirrel.windows-$SquirrelVersion-patched.7z"
+$repoRoot      = "C:\s\Squirrel.Windows"
+$artifactDir   = Join-Path $PSScriptRoot "out\squirrel.windows"
+$outputDir     = Join-Path $repoRoot "build\artifacts"
+$archivePath   = Join-Path $artifactDir "squirrel.windows-$SquirrelVersion-patched.7z"
 if (-not $PatchPath) {
     $PatchPath = Join-Path $PSScriptRoot "patches"
 }
 
 # --- Clone source
-Write-Host "`n📥 Cloning Squirrel.Windows..."
+Write-Host "`n📥 Cloning Squirrel.Windows $SquirrelVersion ..."
 if (Test-Path $repoRoot) {
     Remove-Item $repoRoot -Recurse -Force
 }
@@ -26,9 +26,7 @@ git submodule update --init --recursive
 
 # --- Optional patches
 if ($PatchPath -and (Test-Path $PatchPath) -and (Get-Item $PatchPath).PSIsContainer) {
-    $patchFiles = Get-ChildItem -Path $PatchPath -Filter *.patch
-
-    foreach ($patch in $patchFiles) {
+    foreach ($patch in (Get-ChildItem -Path $PatchPath -Filter *.patch)) {
         Write-Host "`n🔧 Applying patch: $($patch.FullName)"
         git apply $patch.FullName
     }
@@ -45,67 +43,86 @@ $vendorDir = Join-Path $outputDir "electron-winstaller\vendor"
 New-Item -ItemType Directory -Force -Path $vendorDir | Out-Null
 
 $copyMap = @{
-    ".\build\Release\net45\Update.exe"              = "Squirrel.exe"
-    ".\build\Release\net45\update.com"              = "Squirrel.com"
-    ".\build\Release\net45\Update.pdb"              = "Squirrel.pdb"
-    ".\build\Release\Win32\Setup.exe"               = "Setup.exe"
-    ".\build\Release\Win32\Setup.pdb"               = "Setup.pdb"
-    ".\build\Release\net45\Update-Mono.exe"         = "Squirrel-Mono.exe"
-    ".\build\Release\net45\Update-Mono.pdb"         = "Squirrel-Mono.pdb"
-    ".\build\Release\Win32\StubExecutable.exe"      = "StubExecutable.exe"
-    ".\build\Release\net45\SyncReleases.exe"        = "SyncReleases.exe"
-    ".\build\Release\net45\SyncReleases.pdb"        = "SyncReleases.pdb"
-    ".\build\Release\Win32\WriteZipToSetup.exe"     = "WriteZipToSetup.exe"
-    ".\build\Release\Win32\WriteZipToSetup.pdb"     = "WriteZipToSetup.pdb"
+    ".\build\Release\net45\Update.exe"          = "Squirrel.exe"
+    ".\build\Release\net45\update.com"          = "Squirrel.com"
+    ".\build\Release\net45\Update.pdb"          = "Squirrel.pdb"
+    ".\build\Release\Win32\Setup.exe"           = "Setup.exe"
+    ".\build\Release\Win32\Setup.pdb"           = "Setup.pdb"
+    ".\build\Release\net45\Update-Mono.exe"     = "Squirrel-Mono.exe"
+    ".\build\Release\net45\Update-Mono.pdb"     = "Squirrel-Mono.pdb"
+    ".\build\Release\Win32\StubExecutable.exe"  = "StubExecutable.exe"
+    ".\build\Release\net45\SyncReleases.exe"    = "SyncReleases.exe"
+    ".\build\Release\net45\SyncReleases.pdb"    = "SyncReleases.pdb"
+    ".\build\Release\Win32\WriteZipToSetup.exe" = "WriteZipToSetup.exe"
+    ".\build\Release\Win32\WriteZipToSetup.pdb" = "WriteZipToSetup.pdb"
 }
 
 foreach ($src in $copyMap.Keys) {
-    $dest = Join-Path $vendorDir $copyMap[$src]
-    Copy-Item $src -Destination $dest -Force
+    Copy-Item $src -Destination (Join-Path $vendorDir $copyMap[$src]) -Force
 }
+Write-Host "`n✅ Squirrel executables copied."
 
-Write-Host "`n✅ Build completed successfully!"
+# --- nuget.exe
+# The build already ran `nuget restore` and `nuget pack`, so nuget.exe is guaranteed
+# to be in PATH. Capture it here so it ships inside the vendor bundle and does not
+# need to be downloaded at runtime on end-user machines.
+Write-Host "`n📦 Bundling nuget.exe..."
+$nugetSrc = (Get-Command nuget.exe -ErrorAction Stop).Source
+Copy-Item $nugetSrc (Join-Path $vendorDir "nuget.exe") -Force
+Write-Host "  Source: $nugetSrc"
 
-# --- Copy LICENSE from cloned repo before cleanup
-$licenseSrc = Join-Path $repoRoot "LICENSE"
-$licenseDest = Join-Path $vendorDir "LICENSE"
-if (Test-Path $licenseSrc) {
-    Copy-Item $licenseSrc -Destination $licenseDest -Force
-    Write-Host "`n✅ LICENSE copied to vendor directory"
-} else {
-    Write-Error "`n⚠️ LICENSE not found in cloned repo at $licenseSrc"
+# --- 7-Zip binaries
+# Ship both a pre-selected 7z.exe/dll (x64, the host arch on GitHub Actions windows runners)
+# and the arch-specific named copies that select7zipArch in electron-builder uses when
+# cross-compiling for a different target arch.
+Write-Host "`n📦 Bundling 7-Zip binaries..."
+$7zDir = "C:\Program Files\7-Zip"
+if (-not (Test-Path "$7zDir\7z.exe")) {
+    Write-Error "7-Zip not found at $7zDir — ensure 7-Zip is installed on the runner."
     exit 1
 }
+foreach ($f in @("7z.exe", "7z.dll")) {
+    Copy-Item "$7zDir\$f" (Join-Path $vendorDir $f) -Force
+}
+# x64 arch-specific copies (mirrors what electron-winstaller's npm postinstall script does)
+Copy-Item "$7zDir\7z.exe" (Join-Path $vendorDir "7z-x64.exe") -Force
+Copy-Item "$7zDir\7z.dll" (Join-Path $vendorDir "7z-x64.dll") -Force
+Write-Host "  7z x64 binaries bundled."
 
-# --- Ensure output directory exists
+# --- LICENSE
+$licenseSrc = Join-Path $repoRoot "LICENSE"
+if (-not (Test-Path $licenseSrc)) {
+    Write-Error "LICENSE not found in cloned repo at $licenseSrc"
+    exit 1
+}
+Copy-Item $licenseSrc (Join-Path $vendorDir "LICENSE") -Force
+Write-Host "`n✅ LICENSE copied."
+
+# --- Compress
 if (-not (Test-Path $artifactDir)) {
     New-Item -ItemType Directory -Path $artifactDir -Force | Out-Null
 }
-
-# --- Compress the output
 if (Test-Path $archivePath) {
     Remove-Item $archivePath -Force
 }
 
+Set-Location $PSScriptRoot
 Write-Host "`n📦 Compressing to: $archivePath"
 & 7z a -t7z -mx=9 $archivePath "$outputDir\*" | Out-Null
-
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "❌ Compression failed"
+    Write-Error "Compression failed (exit $LASTEXITCODE)"
     exit $LASTEXITCODE
 }
 
 Write-Host "`n✅ Done!"
-Write-Host "🗂️ Archive located at: $archivePath"
-Write-Host ("📦 Archive size: {0:N0} bytes" -f (Get-Item $archivePath).Length)
+Write-Host "🗂️  $archivePath"
+Write-Host ("📦 Size: {0:N0} bytes" -f (Get-Item $archivePath).Length)
 
-# --- Clean up repo root
+# --- Clean up
 Write-Host "`n🧹 Cleaning up $repoRoot..."
 try {
-    Set-Location $PSScriptRoot  # Ensure we’re not inside $repoRoot
     Remove-Item $repoRoot -Recurse -Force -ErrorAction Stop
-    Write-Host "✅ Repo root cleaned up successfully."
-}
-catch {
-    Write-Warning "⚠️ Failed to clean up ${repoRoot}: $_"
+    Write-Host "✅ Cleaned up."
+} catch {
+    Write-Warning "Failed to clean up ${repoRoot}: $_"
 }

--- a/packages/squirrel.windows/build.ps1
+++ b/packages/squirrel.windows/build.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = "Stop"
 $repoRoot      = "C:\s\Squirrel.Windows"
 $artifactDir   = Join-Path $PSScriptRoot "out\squirrel.windows"
 $outputDir     = Join-Path $repoRoot "build\artifacts"
-$archivePath   = Join-Path $artifactDir "squirrel.windows-$SquirrelVersion-patched.7z"
+$archivePath   = Join-Path $artifactDir "squirrel.windows-$SquirrelVersion-patched.tar.gz"
 if (-not $PatchPath) {
     $PatchPath = Join-Path $PSScriptRoot "patches"
 }
@@ -143,7 +143,7 @@ if (Test-Path $archivePath) {
 
 Set-Location $PSScriptRoot
 Write-Host "`n📦 Compressing to: $archivePath"
-& 7z a -t7z -mx=9 $archivePath "$outputDir\*" | Out-Null
+& 7z a -ttar -so "$outputDir\*" | & 7z a -tgzip -mx=9 -si $archivePath | Out-Null
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Compression failed (exit $LASTEXITCODE)"
     exit $LASTEXITCODE

--- a/packages/squirrel.windows/build.ps1
+++ b/packages/squirrel.windows/build.ps1
@@ -32,16 +32,33 @@ if ($PatchPath -and (Test-Path $PatchPath) -and (Get-Item $PatchPath).PSIsContai
     }
 }
 
+# --- Ensure .NET 4.5 reference assemblies are available
+# windows-2022 runners don't ship the .NET 4.5 targeting pack.  The reference-assemblies
+# NuGet package provides them but only auto-wires for SDK-style (PackageReference) projects.
+# The vendored NuGet source inside Squirrel.Windows uses old-style packages.config, so we
+# install the package explicitly and pass FrameworkPathOverride to MSBuild.
+Write-Host "`n📦 Installing .NET 4.5 reference assemblies..."
+$net45PkgDir = Join-Path $env:TEMP "net45-refassemblies"
+nuget install Microsoft.NETFramework.ReferenceAssemblies.net45 -Version 1.0.3 `
+    -NonInteractive -OutputDirectory $net45PkgDir | Out-Null
+if ($LASTEXITCODE -ne 0) { Write-Error "Failed to install .NET 4.5 reference assemblies (exit $LASTEXITCODE)"; exit $LASTEXITCODE }
+$net45Path = Join-Path $net45PkgDir "Microsoft.NETFramework.ReferenceAssemblies.net45.1.0.3\build\.NETFramework\v4.5\"
+Write-Host "  .NET 4.5 refs: $net45Path"
+
 # --- Run the official build
 Write-Host "`n🏗️ Running build steps..."
 
 nuget restore .\Squirrel.sln
 if ($LASTEXITCODE -ne 0) { Write-Error "nuget restore failed (exit $LASTEXITCODE)"; exit $LASTEXITCODE }
 
-# PlatformToolset=v143 retargets the C++ projects (Setup, StubExecutable, WriteZipToSetup)
-# to the VS 2022 toolchain. windows-2022 runners ship v143 but not the v141 (VS 2017)
-# toolset that Squirrel.Windows 2.0.1's vcxproj files request by default.
-msbuild -Restore .\Squirrel.sln -p:Configuration=Release -p:PlatformToolset=v143 -v:m -m -nr:false -bl:.\build\logs\build.binlog
+# PlatformToolset=v143  — retargets C++ projects (Setup, StubExecutable, WriteZipToSetup)
+#   from v141 (VS 2017) to v143 (VS 2022). windows-2022 runners ship v143 only.
+# FrameworkPathOverride  — points packages.config .NET 4.5 projects at the reference
+#   assemblies installed above; without this, MSBuild raises MSB3644 on the vendored
+#   nuget source inside Squirrel.Windows.
+msbuild -Restore .\Squirrel.sln -p:Configuration=Release -p:PlatformToolset=v143 `
+    "-p:FrameworkPathOverride=$net45Path" `
+    -v:m -m -nr:false -bl:.\build\logs\build.binlog
 if ($LASTEXITCODE -ne 0) { Write-Error "msbuild failed (exit $LASTEXITCODE)"; exit $LASTEXITCODE }
 
 nuget pack .\src\Squirrel.nuspec -OutputDirectory .\build\artifacts


### PR DESCRIPTION
This pull request updates the Squirrel.Windows packaging process to bundle `nuget.exe` and 7-Zip binaries directly into the vendor directory, ensuring these dependencies are available at runtime without additional downloads. It also updates the build environment to use a newer Windows runner and includes several improvements and cleanups in the build script.

**Packaging improvements:**
* The build now bundles `nuget.exe` and 7-Zip binaries (`7z.exe`, `7z.dll`, and x64-specific copies) into the `vendor` directory, ensuring these tools are shipped with the package and do not need to be downloaded on end-user machines. [[1]](diffhunk://#diff-b65263c2aa0e71ef9553f894c1e709b2b990acd6408127c84d1a70ac8357c3f9R1-R5) [[2]](diffhunk://#diff-c427d376acf40cd2c30ae6c614cb9d8da0f48ebcb9883a2c18471228b3bcf2d1L63-R127)

**Build environment updates:**
* The GitHub Actions workflow has been updated to use the `windows-2022` runner instead of `windows-2019` for improved compatibility and support.
