### PR TITLE
fix(icons): replace png2icons with wasm-vips Lanczos3 resampling for high-quality icon conversion

### DIFF
--- a/.changeset/icons-bezier-resize.md
+++ b/.changeset/icons-bezier-resize.md
@@ -1,0 +1,5 @@
+---
+"icons": patch
+---
+
+fix(icons): replace BILINEAR with BEZIER resampling and pre-resize ICO to 256×256 via resvg-wasm

--- a/.changeset/icons-bezier-resize.md
+++ b/.changeset/icons-bezier-resize.md
@@ -1,5 +1,5 @@
 ---
-"icons": patch
+"icons": minor
 ---
 
-fix(icons): replace BILINEAR with BEZIER resampling and pre-resize ICO to 256×256 via resvg-wasm
+fix(icons): replace png2icons with wasm-vips Lanczos3 resampling for high-quality icon conversion

--- a/packages/icons/assets/build.sh
+++ b/packages/icons/assets/build.sh
@@ -79,14 +79,21 @@ do_build() {
     echo "  ✓ resvg.wasm copied ($(du -h "$BUNDLE_DIR/resvg.wasm" | cut -f1))"
 
     echo ""
-    echo "─── Copy vips.wasm ─────────────────────────────────────────────"
+    echo "─── Copy vips.wasm + vips-node.js ─────────────────────────────"
     local vips_wasm_path="$PACKAGE_DIR/node_modules/wasm-vips/lib/vips.wasm"
+    local vips_node_js_path="$PACKAGE_DIR/node_modules/wasm-vips/lib/vips-node.js"
     if [ ! -f "$vips_wasm_path" ]; then
         echo "ERROR: Could not locate wasm-vips/lib/vips.wasm — is the package installed?"
         exit 1
     fi
+    if [ ! -f "$vips_node_js_path" ]; then
+        echo "ERROR: Could not locate wasm-vips/lib/vips-node.js — is the package installed?"
+        exit 1
+    fi
     cp "$vips_wasm_path" "$BUNDLE_DIR/vips.wasm"
+    cp "$vips_node_js_path" "$BUNDLE_DIR/vips-node.js"
     echo "  ✓ vips.wasm copied ($(du -h "$BUNDLE_DIR/vips.wasm" | cut -f1))"
+    echo "  ✓ vips-node.js copied ($(du -h "$BUNDLE_DIR/vips-node.js" | cut -f1))"
 
     echo ""
     echo "─── Create tar.gz archive ──────────────────────────────────────"

--- a/packages/icons/assets/build.sh
+++ b/packages/icons/assets/build.sh
@@ -79,6 +79,16 @@ do_build() {
     echo "  ✓ resvg.wasm copied ($(du -h "$BUNDLE_DIR/resvg.wasm" | cut -f1))"
 
     echo ""
+    echo "─── Copy vips.wasm ─────────────────────────────────────────────"
+    local vips_wasm_path="$PACKAGE_DIR/node_modules/wasm-vips/lib/vips.wasm"
+    if [ ! -f "$vips_wasm_path" ]; then
+        echo "ERROR: Could not locate wasm-vips/lib/vips.wasm — is the package installed?"
+        exit 1
+    fi
+    cp "$vips_wasm_path" "$BUNDLE_DIR/vips.wasm"
+    echo "  ✓ vips.wasm copied ($(du -h "$BUNDLE_DIR/vips.wasm" | cut -f1))"
+
+    echo ""
     echo "─── Create tar.gz archive ──────────────────────────────────────"
     local archive_name="icons-bundle.tar.gz"
     (

--- a/packages/icons/assets/src/cli.ts
+++ b/packages/icons/assets/src/cli.ts
@@ -72,7 +72,7 @@ async function main(): Promise<void> {
       createIcns(pngBuffer, outDir)
       break
     case 'ico':
-      createIco(pngBuffer, outDir)
+      await createIco(pngBuffer, outDir)
       break
     case 'set':
       await createLinuxSet(pngBuffer, outDir)

--- a/packages/icons/assets/src/cli.ts
+++ b/packages/icons/assets/src/cli.ts
@@ -69,7 +69,7 @@ async function main(): Promise<void> {
 
   switch (format) {
     case 'icns':
-      createIcns(pngBuffer, outDir)
+      await createIcns(pngBuffer, outDir)
       break
     case 'ico':
       await createIco(pngBuffer, outDir)

--- a/packages/icons/assets/src/icns.ts
+++ b/packages/icons/assets/src/icns.ts
@@ -1,9 +1,54 @@
 import { writeFileSync } from 'fs'
 import { join } from 'path'
-import * as png2icons from 'png2icons'
+import { resizeWithLanczos } from './vips'
 
-export function createIcns(inputBuffer: Buffer, outputDir: string): void {
-  const icnsBuffer = png2icons.createICNS(inputBuffer, png2icons.BEZIER, 0)
-  if (!icnsBuffer) throw new Error('png2icons failed to create ICNS — ensure input is a valid PNG (1024×1024 recommended)')
-  writeFileSync(join(outputDir, 'icon.icns'), icnsBuffer)
+// Standard macOS ICNS entries. HiDPI entries (ic11–ic14) carry the same pixel
+// data as their standard counterparts — same render dimensions, different logical
+// resolution label. Both are required by macOS for correct HiDPI display.
+const ICNS_ENTRIES: Array<{ osType: string; size: number }> = [
+  { osType: 'icp4', size: 16 },
+  { osType: 'icp5', size: 32 },
+  { osType: 'icp6', size: 64 },
+  { osType: 'ic07', size: 128 },
+  { osType: 'ic08', size: 256 },
+  { osType: 'ic09', size: 512 },
+  { osType: 'ic10', size: 1024 },
+  { osType: 'ic11', size: 32 },    // 16@2x
+  { osType: 'ic12', size: 64 },    // 32@2x
+  { osType: 'ic13', size: 512 },   // 256@2x
+  { osType: 'ic14', size: 1024 },  // 512@2x
+]
+
+// Pack pre-sized PNG frames into an ICNS container.
+function packIcns(frames: Array<{ osType: string; png: Buffer }>): Buffer {
+  const chunks = frames.flatMap(({ osType, png }) => {
+    const hdr = Buffer.allocUnsafe(8)
+    Buffer.from(osType, 'ascii').copy(hdr, 0)
+    hdr.writeUInt32BE(8 + png.length, 4)
+    return [hdr, png]
+  })
+  const body = Buffer.concat(chunks)
+  const fileHeader = Buffer.allocUnsafe(8)
+  Buffer.from('icns', 'ascii').copy(fileHeader, 0)
+  fileHeader.writeUInt32BE(8 + body.length, 4)
+  return Buffer.concat([fileHeader, body])
+}
+
+export async function createIcns(inputBuffer: Buffer, outputDir: string): Promise<void> {
+  // Determine source size from the PNG IHDR chunk to avoid upscaling
+  const sourceSize = inputBuffer.readUInt32BE(16)
+
+  const entries = ICNS_ENTRIES.filter(e => e.size <= sourceSize)
+
+  // Generate each unique pixel size once, reuse for HiDPI duplicates
+  const uniqueSizes = [...new Set(entries.map(e => e.size))]
+  const pngBySize = new Map<number, Buffer>()
+  await Promise.all(
+    uniqueSizes.map(async size => {
+      pngBySize.set(size, await resizeWithLanczos(inputBuffer, size))
+    })
+  )
+
+  const frames = entries.map(({ osType, size }) => ({ osType, png: pngBySize.get(size)! }))
+  writeFileSync(join(outputDir, 'icon.icns'), packIcns(frames))
 }

--- a/packages/icons/assets/src/icns.ts
+++ b/packages/icons/assets/src/icns.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import * as png2icons from 'png2icons'
 
 export function createIcns(inputBuffer: Buffer, outputDir: string): void {
-  const icnsBuffer = png2icons.createICNS(inputBuffer, png2icons.BILINEAR, 0)
+  const icnsBuffer = png2icons.createICNS(inputBuffer, png2icons.BEZIER, 0)
   if (!icnsBuffer) throw new Error('png2icons failed to create ICNS — ensure input is a valid PNG (1024×1024 recommended)')
   writeFileSync(join(outputDir, 'icon.icns'), icnsBuffer)
 }

--- a/packages/icons/assets/src/ico.ts
+++ b/packages/icons/assets/src/ico.ts
@@ -1,9 +1,17 @@
 import { writeFileSync } from 'fs'
 import { join } from 'path'
 import * as png2icons from 'png2icons'
+import { resizePng } from './svg'
 
-export function createIco(inputBuffer: Buffer, outputDir: string): void {
-  const icoBuffer = png2icons.createICO(inputBuffer, png2icons.BILINEAR, 0, false)
-  if (!icoBuffer) throw new Error('png2icons failed to create ICO — ensure input is a valid PNG (512×512 or larger recommended)')
+// ICO directory entries store width/height as a single byte (0 = 256), so 256×256
+// is the maximum frame size. Pre-resizing to exactly 256×256 via resvg-wasm
+// (high-quality resampling) gives png2icons a clean source for generating the
+// smaller sizes (16, 32, 48, …), matching the Go icon-converter's Lanczos approach.
+const ICO_MAX_SIZE = 256
+
+export async function createIco(inputBuffer: Buffer, outputDir: string): Promise<void> {
+  const resized = await resizePng(inputBuffer, ICO_MAX_SIZE)
+  const icoBuffer = png2icons.createICO(resized, png2icons.BEZIER, 0, false)
+  if (!icoBuffer) throw new Error('png2icons failed to create ICO — ensure input is a valid PNG (256×256 or larger recommended)')
   writeFileSync(join(outputDir, 'icon.ico'), icoBuffer)
 }

--- a/packages/icons/assets/src/ico.ts
+++ b/packages/icons/assets/src/ico.ts
@@ -1,17 +1,42 @@
 import { writeFileSync } from 'fs'
 import { join } from 'path'
-import * as png2icons from 'png2icons'
-import { resizePng } from './svg'
+import { resizeWithLanczos } from './vips'
 
-// ICO directory entries store width/height as a single byte (0 = 256), so 256×256
-// is the maximum frame size. Pre-resizing to exactly 256×256 via resvg-wasm
-// (high-quality resampling) gives png2icons a clean source for generating the
-// smaller sizes (16, 32, 48, …), matching the Go icon-converter's Lanczos approach.
-const ICO_MAX_SIZE = 256
+const ICO_SIZES = [16, 24, 32, 48, 64, 128, 256]
+
+// Pack pre-sized PNG frames into a Vista+ ICO container.
+// PNG frames are embedded directly (valid from Windows Vista onward);
+// byte value 0 in the directory width/height field encodes 256.
+function packIco(frames: Array<{ size: number; png: Buffer }>): Buffer {
+  const count = frames.length
+  let offset = 6 + count * 16
+
+  const header = Buffer.allocUnsafe(6)
+  header.writeUInt16LE(0, 0)
+  header.writeUInt16LE(1, 2)
+  header.writeUInt16LE(count, 4)
+
+  const dir = frames.map(({ size, png }) => {
+    const entry = Buffer.allocUnsafe(16)
+    const w = size === 256 ? 0 : size
+    entry.writeUInt8(w, 0)
+    entry.writeUInt8(w, 1)
+    entry.writeUInt8(0, 2)        // color count (0 = true-color)
+    entry.writeUInt8(0, 3)        // reserved
+    entry.writeUInt16LE(1, 4)     // planes
+    entry.writeUInt16LE(32, 6)    // bits per pixel
+    entry.writeUInt32LE(png.length, 8)
+    entry.writeUInt32LE(offset, 12)
+    offset += png.length
+    return entry
+  })
+
+  return Buffer.concat([header, ...dir, ...frames.map(f => f.png)])
+}
 
 export async function createIco(inputBuffer: Buffer, outputDir: string): Promise<void> {
-  const resized = await resizePng(inputBuffer, ICO_MAX_SIZE)
-  const icoBuffer = png2icons.createICO(resized, png2icons.BEZIER, 0, false)
-  if (!icoBuffer) throw new Error('png2icons failed to create ICO — ensure input is a valid PNG (256×256 or larger recommended)')
-  writeFileSync(join(outputDir, 'icon.ico'), icoBuffer)
+  const frames = await Promise.all(
+    ICO_SIZES.map(async size => ({ size, png: await resizeWithLanczos(inputBuffer, size) }))
+  )
+  writeFileSync(join(outputDir, 'icon.ico'), packIco(frames))
 }

--- a/packages/icons/assets/src/linux.ts
+++ b/packages/icons/assets/src/linux.ts
@@ -1,16 +1,12 @@
 import { writeFileSync } from 'fs'
 import { join } from 'path'
-import { svgToPng } from './svg'
+import { resizeWithLanczos } from './vips'
 
 const LINUX_SIZES = [16, 24, 32, 48, 64, 128, 256, 512]
 
-// Resize by wrapping the PNG in an SVG image element and rendering via resvg-wasm.
-// This reuses the wasm already bundled for SVG support — no extra dependencies.
 export async function createLinuxSet(inputBuffer: Buffer, outputDir: string): Promise<void> {
-  const b64 = inputBuffer.toString('base64')
   for (const size of LINUX_SIZES) {
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${size}" height="${size}"><image href="data:image/png;base64,${b64}" width="${size}" height="${size}"/></svg>`
-    const resized = await svgToPng(Buffer.from(svg), size)
+    const resized = await resizeWithLanczos(inputBuffer, size)
     writeFileSync(join(outputDir, `${size}x${size}.png`), resized)
   }
 }

--- a/packages/icons/assets/src/svg.ts
+++ b/packages/icons/assets/src/svg.ts
@@ -25,3 +25,12 @@ export async function svgToPng(svgData: Buffer, targetWidth: number): Promise<Bu
   const rendered = resvg.render()
   return Buffer.from(rendered.asPng())
 }
+
+// Resize a PNG buffer to targetWidth×targetWidth using resvg-wasm.
+// Wraps the PNG in an SVG <image> element — the same high-quality resampling
+// path that createLinuxSet uses — so no additional dependencies are needed.
+export async function resizePng(pngBuffer: Buffer, targetWidth: number): Promise<Buffer> {
+  const b64 = pngBuffer.toString('base64')
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${targetWidth}" height="${targetWidth}"><image href="data:image/png;base64,${b64}" width="${targetWidth}" height="${targetWidth}"/></svg>`
+  return svgToPng(Buffer.from(svg), targetWidth)
+}

--- a/packages/icons/assets/src/svg.ts
+++ b/packages/icons/assets/src/svg.ts
@@ -25,12 +25,3 @@ export async function svgToPng(svgData: Buffer, targetWidth: number): Promise<Bu
   const rendered = resvg.render()
   return Buffer.from(rendered.asPng())
 }
-
-// Resize a PNG buffer to targetWidth×targetWidth using resvg-wasm.
-// Wraps the PNG in an SVG <image> element — the same high-quality resampling
-// path that createLinuxSet uses — so no additional dependencies are needed.
-export async function resizePng(pngBuffer: Buffer, targetWidth: number): Promise<Buffer> {
-  const b64 = pngBuffer.toString('base64')
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${targetWidth}" height="${targetWidth}"><image href="data:image/png;base64,${b64}" width="${targetWidth}" height="${targetWidth}"/></svg>`
-  return svgToPng(Buffer.from(svg), targetWidth)
-}

--- a/packages/icons/assets/src/vips.ts
+++ b/packages/icons/assets/src/vips.ts
@@ -1,17 +1,32 @@
+import { readFileSync } from 'fs'
 import { join } from 'path'
 
+// Load vips-node.js as a sidecar at runtime (NOT bundled by esbuild).
+// When bundled, vips-node.js sets ha=__filename to the bundle path, causing workers to
+// re-enter the bundle and deadlock. Loaded as a sidecar, ha=__filename points to
+// vips-node.js itself, so workers spawn independently without touching the bundle.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const VipsFactory = require('wasm-vips')
+const VipsFactory = require(join(__dirname, 'vips-node.js'))
 
 let vipsInstance: any = null
 
 async function getVips(): Promise<any> {
   if (vipsInstance) return vipsInstance
+  // Bypass the default Emscripten WASM loader (which fails inside esbuild bundles)
+  // by pre-reading the WASM binary and using instantiateWasm directly — the same
+  // pattern resvg-wasm uses for its init. Skip optional codecs (HEIF, JXL, resvg).
+  const wasmBuffer = readFileSync(join(__dirname, 'vips.wasm'))
   vipsInstance = await VipsFactory({
-    // Skip optional codecs (HEIF, JXL, resvg) — only PNG resize is needed
     dynamicLibraries: [],
-    // Redirect WASM loading to our bundled vips.wasm next to icon-tool.js
-    locateFile: (url: string) => join(__dirname, url),
+    instantiateWasm: (
+      imports: WebAssembly.Imports,
+      receiveInstance: (inst: WebAssembly.Instance, mod: WebAssembly.Module) => void
+    ) => {
+      WebAssembly.instantiate(wasmBuffer, imports).then(result => {
+        receiveInstance(result.instance, result.module)
+      })
+      return {}
+    },
   })
   return vipsInstance
 }

--- a/packages/icons/assets/src/vips.ts
+++ b/packages/icons/assets/src/vips.ts
@@ -1,0 +1,31 @@
+import { join } from 'path'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const VipsFactory = require('wasm-vips')
+
+let vipsInstance: any = null
+
+async function getVips(): Promise<any> {
+  if (vipsInstance) return vipsInstance
+  vipsInstance = await VipsFactory({
+    // Skip optional codecs (HEIF, JXL, resvg) — only PNG resize is needed
+    dynamicLibraries: [],
+    // Redirect WASM loading to our bundled vips.wasm next to icon-tool.js
+    locateFile: (url: string) => join(__dirname, url),
+  })
+  return vipsInstance
+}
+
+// Resize a PNG buffer to exactly targetSize×targetSize using Lanczos3 resampling.
+// Uses vips thumbnail algorithm: box-filter pre-shrink + Lanczos final stage,
+// matching the quality approach of the Go icon-converter's imaging.Lanczos.
+export async function resizeWithLanczos(pngBuffer: Buffer, targetSize: number): Promise<Buffer> {
+  const vips = await getVips()
+  const out = vips.Image.thumbnailBuffer(pngBuffer, targetSize, {
+    height: targetSize,
+    size: vips.Size.force,
+  })
+  const result = Buffer.from(out.writeToBuffer('.png'))
+  out.delete()
+  return result
+}

--- a/packages/icons/assets/tsconfig.json
+++ b/packages/icons/assets/tsconfig.json
@@ -6,7 +6,9 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "outDir": "../out"
+    "outDir": "../out",
+    "typeRoots": ["../../../node_modules/@types"],
+    "types": ["node"]
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"]
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -4,6 +4,6 @@
     "description": "Portable icon conversion toolset for electron-builder — converts PNG/SVG to ICNS (macOS), ICO (Windows), and Linux PNG sets. Zero native dependencies; bundled as a single Node.js script with WebAssembly SVG support.",
     "dependencies": {
         "@resvg/resvg-wasm": "^2.6.2",
-        "png2icons": "^2.0.1"
+        "wasm-vips": "^0.0.17"
     }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,7 @@
 {
     "name": "icons",
     "version": "1.0.1",
-    "description": "Portable icon conversion toolset for electron-builder — converts PNG/SVG to ICNS (macOS), ICO (Windows), and Linux PNG sets. Zero native dependencies; bundled as a single Node.js script with WebAssembly SVG support.",
+    "description": "Portable icon conversion toolset for electron-builder — converts PNG/SVG/ICNS to ICNS (macOS), ICO (Windows), and Linux PNG sets. Uses Lanczos3 resampling via wasm-vips and SVG rasterization via resvg-wasm. Zero native dependencies; bundled as a single Node.js script.",
     "dependencies": {
         "@resvg/resvg-wasm": "^2.6.2",
         "wasm-vips": "^0.0.17"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,9 +55,9 @@ importers:
       '@resvg/resvg-wasm':
         specifier: ^2.6.2
         version: 2.6.2
-      png2icons:
-        specifier: ^2.0.1
-        version: 2.0.1
+      wasm-vips:
+        specifier: ^0.0.17
+        version: 0.0.17
 
   packages/linux-tools-mac: {}
 
@@ -72,6 +72,126 @@ importers:
   packages/win-codesign: {}
 
   packages/wine: {}
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2:
+    devDependencies:
+      '@actions/attest':
+        specifier: ^3.2.0
+        version: 3.2.0(@octokit/core@7.0.6)
+      '@changesets/changelog-github':
+        specifier: ^0.7.0
+        version: 0.7.0(encoding@0.1.13)
+      '@changesets/cli':
+        specifier: ^2.30.0
+        version: 2.31.0(@types/node@18.19.130)
+      '@octokit/rest':
+        specifier: 22.0.1
+        version: 22.0.1
+      '@types/node':
+        specifier: ^18.0.0
+        version: 18.19.130
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.0
+      mime-types:
+        specifier: ^3.0.2
+        version: 3.0.2
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/7zip: {}
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/appimage: {}
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/dmg-builder: {}
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/fpm: {}
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/icons:
+    dependencies:
+      '@resvg/resvg-wasm':
+        specifier: ^2.6.2
+        version: 2.6.2
+      wasm-vips:
+        specifier: ^0.0.17
+        version: 0.0.17
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/linux-tools-mac: {}
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/nsis: {}
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/ran: {}
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/snap-template: {}
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/squirrel.windows: {}
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/win-codesign: {}
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/wine: {}
+
+  packages/wine/build/wine-11.0-darwin-x86_64/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/wix: {}
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2:
+    devDependencies:
+      '@actions/attest':
+        specifier: ^3.2.0
+        version: 3.2.0(@octokit/core@7.0.6)
+      '@changesets/changelog-github':
+        specifier: ^0.7.0
+        version: 0.7.0(encoding@0.1.13)
+      '@changesets/cli':
+        specifier: ^2.30.0
+        version: 2.31.0(@types/node@18.19.130)
+      '@octokit/rest':
+        specifier: 22.0.1
+        version: 22.0.1
+      '@types/node':
+        specifier: ^18.0.0
+        version: 18.19.130
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.0
+      mime-types:
+        specifier: ^3.0.2
+        version: 3.0.2
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/7zip: {}
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/appimage: {}
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/dmg-builder: {}
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/fpm: {}
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/icons:
+    dependencies:
+      '@resvg/resvg-wasm':
+        specifier: ^2.6.2
+        version: 2.6.2
+      wasm-vips:
+        specifier: ^0.0.17
+        version: 0.0.17
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/linux-tools-mac: {}
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/nsis: {}
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/ran: {}
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/snap-template: {}
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/squirrel.windows: {}
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/win-codesign: {}
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/wine: {}
+
+  packages/wine/build/wine-stage/wine-home/dosdevices/z:/Users/mikemaietta/Development/electron-builder-binaries-2/packages/wix: {}
 
   packages/wix: {}
 
@@ -848,10 +968,6 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  png2icons@2.0.1:
-    resolution: {integrity: sha512-GDEQJr8OG4e6JMp7mABtXFSEpgJa1CCpbQiAR+EjhkHJHnUL9zPPtbOrjsMD8gUbikgv3j7x404b0YJsV3aVFA==}
-    hasBin: true
-
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -1004,6 +1120,10 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  wasm-vips@0.0.17:
+    resolution: {integrity: sha512-nhkqUNJDUymImoXGrVfImC4wzIFTb9KfBpAngb7dcEQNPP1gVTx4+WL3VVVDSXQpMsyeacsQDOx0+DM33Rpurg==}
+    engines: {node: '>=16.4.0'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -1878,8 +1998,6 @@ snapshots:
 
   pify@4.0.1: {}
 
-  png2icons@2.0.1: {}
-
   prettier@2.8.8: {}
 
   proc-log@5.0.0: {}
@@ -2009,6 +2127,8 @@ snapshots:
   universal-user-agent@7.0.3: {}
 
   universalify@0.1.2: {}
+
+  wasm-vips@0.0.17: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
fix(icons): replace png2icons with wasm-vips Lanczos3 resampling for high-quality icon conversion

Replaces the `png2icons` dependency with `wasm-vips` (libvips compiled to WebAssembly) to fix
jagged/aliased edges on generated icons. Resolves electron-userland/electron-builder#9849.

**Root cause:** `png2icons` used bilinear resampling. For large downscaling ratios (e.g. 1024→16 px)
this produced pronounced aliasing. The original Go `app-builder` used `imaging.Lanczos` which
avoids this by applying a windowed sinc filter with multi-pass pre-shrinking.

**What changed:**
- Added `wasm-vips` dependency (libvips 8.x in WASM, ~5.6 MB; no native bindings)
- Removed `png2icons` dependency
- New `vips.ts` singleton: initializes wasm-vips once, exposes `resizeWithLanczos(buffer, size)`
  using vips `thumbnailBuffer` with `Size.force` — the same multi-pass Lanczos3 algorithm vips
  uses for high-quality downsampling
- `ico.ts` rewritten: generates each standard ICO size (16/24/32/48/64/128/256 px) individually
  via Lanczos3, then packs them into a Vista+ PNG-frame ICO container (custom packer, no deps)
- `icns.ts` rewritten: generates all standard ICNS entries up to source size (icp4–ic14) via
  Lanczos3, deduplicates HiDPI/standard entries that share pixel dimensions, packs with a
  custom ICNS container writer
- `linux.ts` updated: switches from the resvg SVG-wrapping resize trick (bicubic) to vips
  Lanczos3 for consistency across all formats
- `build.sh` updated: copies `vips.wasm` alongside `icon-tool.js` in the bundle

Bundle size: ~964 KB → ~3.0 MB (tar.gz); the increase is `vips.wasm` (5.6 MB uncompressed,
~2.4 MB compressed).
