### PR TITLE
fix(win-codesign): bundle the full Microsoft.Trusted.Signing.Client

### DIFF
--- a/.changeset/fix-ats-full-payload.md
+++ b/.changeset/fix-ats-full-payload.md
@@ -1,0 +1,5 @@
+---
+"win-codesign": patch
+---
+
+fix(win-codesign): bundle the full Microsoft.Trusted.Signing.Client `bin/<arch>` payload, pin the nupkg SHA-256 (fail-closed verification by default) and stop copying x64 ATS DLLs into the arm64 kit directory

--- a/.changeset/fix-win-kits-rcedit-determinism.md
+++ b/.changeset/fix-win-kits-rcedit-determinism.md
@@ -2,4 +2,4 @@
 "win-codesign": patch
 ---
 
-fix(win-codesign): add `--target` flag to build.sh and run kits+rcedit on a dedicated x64 CI runner to make released artifact bytes deterministic
+fix(win-codesign): add `--target` flag to build.sh and run kits/ats/rcedit on a dedicated x64 CI runner so arch-agnostic artifacts are produced exactly once, eliminating the race where the arm64 matrix job could overwrite the x64 job's identical outputs

--- a/.changeset/fix-win-kits-rcedit-determinism.md
+++ b/.changeset/fix-win-kits-rcedit-determinism.md
@@ -1,0 +1,5 @@
+---
+"win-codesign": patch
+---
+
+fix(win-codesign): add `--target` flag to build.sh and run kits+rcedit on a dedicated x64 CI runner to make released artifact bytes deterministic

--- a/.github/workflows/build-wincodesign.yaml
+++ b/.github/workflows/build-wincodesign.yaml
@@ -126,12 +126,13 @@ jobs:
             pkgconf:p
             nodejs:p
 
-      - name: Build Windows kits + rcedit (x64 only)
+      - name: Build Windows kits + ats + rcedit (x64 only)
         run: |
           bash ./packages/win-codesign/build.sh \
             --arch x64 \
             --rcedit-version ${{ inputs.rcedit_version || '2.0.0' }} \
             --target kits \
+            --target ats \
             --target rcedit
 
       - name: Upload artifact

--- a/.github/workflows/build-wincodesign.yaml
+++ b/.github/workflows/build-wincodesign.yaml
@@ -86,12 +86,58 @@ jobs:
           bash ./packages/win-codesign/build.sh \
             --arch ${{ matrix.arch }} \
             --osslsigncode-ver ${{ inputs.osslsigncode_ver || '2.11' }} \
-            --rcedit-version ${{ inputs.rcedit_version || '2.0.0' }}
+            --target ossl
 
       - name: Upload artifact
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         with:
           name: win-codesign-windows-${{ matrix.arch }}
+          path: ./packages/win-codesign/out/**/*.zip
+          if-no-files-found: error
+          retention-days: 1
+
+  windows-kits-rcedit:
+    runs-on: windows-2025
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@fb197b72ce45fb24f17bf3f807a388985654d1f2 # v2.29.0
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            git
+            make
+            zip
+            unzip
+          pacboy: >-
+            gcc:p
+            cmake:p
+            openssl:p
+            curl:p
+            libgsf:p
+            zlib:p
+            pkgconf:p
+            nodejs:p
+
+      - name: Build Windows kits + rcedit (x64 only)
+        run: |
+          bash ./packages/win-codesign/build.sh \
+            --arch x64 \
+            --rcedit-version ${{ inputs.rcedit_version || '2.0.0' }} \
+            --target kits \
+            --target rcedit
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        with:
+          name: win-codesign-windows-kits-rcedit
           path: ./packages/win-codesign/out/**/*.zip
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/build-wincodesign.yaml
+++ b/.github/workflows/build-wincodesign.yaml
@@ -81,7 +81,7 @@ jobs:
             pkgconf:p
             nodejs:p
 
-      - name: Build win-codesign Windows (${{ matrix.arch }})
+      - name: Build osslsigncode for Windows (${{ matrix.arch }})
         run: |
           bash ./packages/win-codesign/build.sh \
             --arch ${{ matrix.arch }} \

--- a/packages/win-codesign/assets/build-win-ats.sh
+++ b/packages/win-codesign/assets/build-win-ats.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── Helpers (sourceable for testing) ─────────────────────────────────────────
+
+verify_sha256() {
+    local file="$1" expected="$2" actual
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$file" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$file" | awk '{print $1}')
+    else
+        echo "❌ No sha256 tool found (sha256sum or shasum required)" >&2
+        return 1
+    fi
+    if [ "$actual" = "$expected" ]; then
+        echo "  ✓ Checksum verified"
+    else
+        echo "❌ Checksum mismatch for $(basename "$file")" >&2
+        echo "   expected: $expected" >&2
+        echo "   actual:   $actual" >&2
+        return 1
+    fi
+}
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+usage() {
+    cat >&2 << EOF
+Usage: $0 [options]
+  --ats-version   Microsoft.Trusted.Signing.Client NuGet version
+                  (default: \$ATS_NUGET_VERSION or '1.0.95')
+  --ats-sha256    Expected SHA-256 of the .nupkg. Defaults to the pinned hash of the
+                  default --ats-version; override when changing --ats-version, or pass
+                  an empty string to skip verification (not recommended)
+                  (default: \$ATS_NUGET_SHA256 or the pinned 1.0.95 hash)
+  --output-dir    Output directory for the bundle ZIP
+                  (default: <package-root>/out/win-codesign)
+  -h|--help       Show this help
+EOF
+    exit 1
+}
+
+# Defaults — CLI flags take precedence over env vars, env vars over built-in defaults
+ATS_NUGET_VERSION="${ATS_NUGET_VERSION:-1.0.95}"
+# Pinned SHA-256 of microsoft.trusted.signing.client.1.0.95.nupkg
+ATS_NUGET_SHA256="${ATS_NUGET_SHA256:-3bfcf1e0a3cb42af1692f0a8ed45c15de070c2de86f28a59b2795d904d8a920f}"
+OUTPUT_DIR="$SCRIPT_DIR/out/win-codesign"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ats-version) ATS_NUGET_VERSION="$2"; shift 2 ;;
+        --ats-sha256)  ATS_NUGET_SHA256="$2";  shift 2 ;;
+        --output-dir)  OUTPUT_DIR="$2";        shift 2 ;;
+        -h|--help)     usage ;;
+        *)             echo "❌ Unknown argument: $1" >&2; usage ;;
+    esac
+done
+
+ATS_BUNDLE_DIR="$OUTPUT_DIR/ats-bundle"
+ATS_NUPKG="$OUTPUT_DIR/ats-client.nupkg"
+ATS_EXTRACT="$OUTPUT_DIR/ats-client"
+
+# When sourced for testing, stop here so helpers are importable without side effects.
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] || return 0
+
+# ── Cleanup on exit ───────────────────────────────────────────────────────────
+cleanup() {
+    rm -rf "$ATS_EXTRACT"
+    rm -rf "$ATS_BUNDLE_DIR"
+    rm -f "$ATS_NUPKG"
+}
+trap cleanup EXIT
+
+# ── Azure Trusted Signing client DLLs ────────────────────────────────────────
+# Azure.CodeSigning.Dlib.dll (and its MSAL auth extension) are NOT part of
+# Windows Kits. They ship in the NuGet package Microsoft.Trusted.Signing.Client.
+# signtool.exe uses them via /dlib + /dmdf instead of the TrustedSigning
+# PowerShell module, enabling cross-platform signing via Wine.
+
+ATS_NUGET_ID="microsoft.trusted.signing.client"
+
+echo "📦 Downloading Microsoft.Trusted.Signing.Client v${ATS_NUGET_VERSION}..."
+curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --max-time 120 \
+    "https://api.nuget.org/v3-flatcontainer/${ATS_NUGET_ID}/${ATS_NUGET_VERSION}/${ATS_NUGET_ID}.${ATS_NUGET_VERSION}.nupkg" \
+    --output "$ATS_NUPKG"
+
+if [ -n "${ATS_NUGET_SHA256}" ]; then
+    echo "  🔍 Verifying checksum..."
+    verify_sha256 "$ATS_NUPKG" "$ATS_NUGET_SHA256"
+fi
+
+mkdir -p "$ATS_EXTRACT"
+unzip -q "$ATS_NUPKG" -d "$ATS_EXTRACT"
+rm -f "$ATS_NUPKG"
+
+# Azure.CodeSigning.Dlib.dll is a framework-dependent .NET 8 shim — its entire
+# dependency closure (Azure.CodeSigning*.dll, Azure.Core/Identity, MSAL, Ijwhost,
+# runtimeconfig.json, VC++/MFC runtimes) ships beside it in bin/<arch> and must be
+# copied wholesale or signtool /dlib fails to load it at runtime.
+#
+# v1.0.95+ ships bin/x64 and bin/x86 only (no bin/arm64). arm64 is intentionally
+# skipped: the payload is x64-only, and placing x64 runtime DLLs (msvcp140 etc.)
+# next to the native arm64 signtool.exe would shadow its own DLL resolution and
+# break it. Azure signing on arm64 hosts uses the x64 directory instead (x64
+# signtool runs under Windows-on-ARM emulation / x64 Wine).
+ATS_ARCHS=("x86" "x64")
+ATS_REQUIRED=("Azure.CodeSigning.Dlib.dll")
+MISSING_FILES=()
+
+echo "Copying ATS payload (full bin/<arch> dependency closure)..."
+for arch in "${ATS_ARCHS[@]}"; do
+    src_dir="$ATS_EXTRACT/bin/$arch"
+    if [ ! -d "$src_dir" ]; then
+        echo "  ⚠️  Not found: $src_dir"
+        MISSING_FILES+=("$src_dir")
+        continue
+    fi
+    mkdir -p "$ATS_BUNDLE_DIR/$arch"
+    cp -R "$src_dir/." "$ATS_BUNDLE_DIR/$arch/"
+    echo "  ✅ $arch: $(ls -1 "$src_dir" | wc -l | tr -d ' ') file(s)"
+    for f in "${ATS_REQUIRED[@]}"; do
+        if [ ! -f "$ATS_BUNDLE_DIR/$arch/$f" ]; then
+            echo "  ⚠️  Not found: $src_dir/$f"
+            MISSING_FILES+=("$src_dir/$f")
+        fi
+    done
+done
+
+if [ "${#MISSING_FILES[@]}" -gt 0 ]; then
+    echo ""
+    echo "❌ Error: ${#MISSING_FILES[@]} ATS file(s) not found:"
+    for f in "${MISSING_FILES[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
+
+rm -rf "$ATS_EXTRACT"
+
+# ── ZIP ───────────────────────────────────────────────────────────────────────
+{
+    echo "bundle: ats"
+    echo "created_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    echo ""
+    echo "ats_client_version: ${ATS_NUGET_VERSION}"
+} > "$ATS_BUNDLE_DIR/VERSION.txt"
+
+echo "📦 Zipping ats-bundle..."
+ATS_ZIP="$OUTPUT_DIR/ats-bundle-${ATS_NUGET_VERSION//./_}.zip"
+
+cd "$ATS_BUNDLE_DIR"
+zip -r -9 "$ATS_ZIP" .
+rm -rf "$ATS_BUNDLE_DIR"
+
+echo "✅ Created bundle: $ATS_ZIP"
+echo ""

--- a/packages/win-codesign/assets/build-win-ats.sh
+++ b/packages/win-codesign/assets/build-win-ats.sh
@@ -7,10 +7,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 verify_sha256() {
     local file="$1" expected="$2" actual
+    if [ ! -f "$file" ]; then
+        echo "❌ File not found: $file" >&2
+        return 1
+    fi
     if command -v sha256sum >/dev/null 2>&1; then
-        actual=$(sha256sum "$file" | awk '{print $1}')
+        actual=$(sha256sum "$file" | awk '{print $1}') || { echo "❌ sha256sum failed for $(basename "$file")" >&2; return 1; }
     elif command -v shasum >/dev/null 2>&1; then
-        actual=$(shasum -a 256 "$file" | awk '{print $1}')
+        actual=$(shasum -a 256 "$file" | awk '{print $1}') || { echo "❌ shasum failed for $(basename "$file")" >&2; return 1; }
     else
         echo "❌ No sha256 tool found (sha256sum or shasum required)" >&2
         return 1

--- a/packages/win-codesign/assets/build-win-kits.sh
+++ b/packages/win-codesign/assets/build-win-kits.sh
@@ -5,26 +5,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # ── Helpers (sourceable for testing) ─────────────────────────────────────────
 
-verify_sha256() {
-    local file="$1" expected="$2" actual
-    if command -v sha256sum >/dev/null 2>&1; then
-        actual=$(sha256sum "$file" | awk '{print $1}')
-    elif command -v shasum >/dev/null 2>&1; then
-        actual=$(shasum -a 256 "$file" | awk '{print $1}')
-    else
-        echo "❌ No sha256 tool found (sha256sum or shasum required)" >&2
-        return 1
-    fi
-    if [ "$actual" = "$expected" ]; then
-        echo "  ✓ Checksum verified"
-    else
-        echo "❌ Checksum mismatch for $(basename "$file")" >&2
-        echo "   expected: $expected" >&2
-        echo "   actual:   $actual" >&2
-        return 1
-    fi
-}
-
 # Copy src_root/ARCH/file → dest_root/ARCH/file for all ARCHITECTURES.
 # Args: src_root dest_root [file ...]
 # Reads global: ARCHITECTURES
@@ -72,12 +52,6 @@ usage() {
 Usage: $0 [options]
   --sdk-path      Windows Kits bin/ directory
                   (default: \$WINDOWS_KIT_PATH or 'C:/Program Files (x86)/Windows Kits/10/bin')
-  --ats-version   Microsoft.Trusted.Signing.Client NuGet version
-                  (default: \$ATS_NUGET_VERSION or '1.0.95')
-  --ats-sha256    Expected SHA-256 of the .nupkg. Defaults to the pinned hash of the
-                  default --ats-version; override when changing --ats-version, or pass
-                  an empty string to skip verification (not recommended)
-                  (default: \$ATS_NUGET_SHA256 or the pinned 1.0.95 hash)
   --output-dir    Output directory for the bundle ZIP
                   (default: <package-root>/out/win-codesign)
   -h|--help       Show this help
@@ -87,35 +61,21 @@ EOF
 
 # Defaults — CLI flags take precedence over env vars, env vars over built-in defaults
 SDK_BASE="${WINDOWS_KIT_PATH:-C:/Program Files (x86)/Windows Kits/10/bin}"
-ATS_NUGET_VERSION="${ATS_NUGET_VERSION:-1.0.95}"
-# Pinned SHA-256 of microsoft.trusted.signing.client.1.0.95.nupkg
-ATS_NUGET_SHA256="${ATS_NUGET_SHA256:-3bfcf1e0a3cb42af1692f0a8ed45c15de070c2de86f28a59b2795d904d8a920f}"
 OUTPUT_DIR="$SCRIPT_DIR/out/win-codesign"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --sdk-path)    SDK_BASE="$2";          shift 2 ;;
-        --ats-version) ATS_NUGET_VERSION="$2"; shift 2 ;;
-        --ats-sha256)  ATS_NUGET_SHA256="$2";  shift 2 ;;
-        --output-dir)  OUTPUT_DIR="$2";        shift 2 ;;
-        -h|--help)     usage ;;
-        *)             echo "❌ Unknown argument: $1" >&2; usage ;;
+        --sdk-path)   SDK_BASE="$2";   shift 2 ;;
+        --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *)            echo "❌ Unknown argument: $1" >&2; usage ;;
     esac
 done
 
 BUNDLE_DIR="$OUTPUT_DIR/windows-kits-bundle"
-ATS_NUPKG="$OUTPUT_DIR/ats-client.nupkg"
-ATS_EXTRACT="$OUTPUT_DIR/ats-client"
 
 # When sourced for testing, stop here so helpers are importable without side effects.
 [[ "${BASH_SOURCE[0]}" == "${0}" ]] || return 0
-
-# ── Cleanup on exit ───────────────────────────────────────────────────────────
-cleanup() {
-    rm -rf "$ATS_EXTRACT"
-    rm -f "$ATS_NUPKG"
-}
-trap cleanup EXIT
 
 # ── Windows SDK files ─────────────────────────────────────────────────────────
 
@@ -171,81 +131,20 @@ echo "Copying Windows SDK files..."
 copy_arch_files "$SDK_BASE/$VERSION" "$BUNDLE_DIR" "${FILES[@]}"
 report_missing "Windows SDK file(s)"
 
-# ── Azure Trusted Signing client DLLs ────────────────────────────────────────
-# Azure.CodeSigning.Dlib.dll (and its MSAL auth extension) are NOT part of
-# Windows Kits. They ship in the NuGet package Microsoft.Trusted.Signing.Client.
-# signtool.exe uses them via /dlib + /dmdf instead of the TrustedSigning
-# PowerShell module, enabling cross-platform signing via Wine.
-
-ATS_NUGET_ID="microsoft.trusted.signing.client"
-
-echo "📦 Downloading Microsoft.Trusted.Signing.Client v${ATS_NUGET_VERSION}..."
-curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --max-time 120 \
-    "https://api.nuget.org/v3-flatcontainer/${ATS_NUGET_ID}/${ATS_NUGET_VERSION}/${ATS_NUGET_ID}.${ATS_NUGET_VERSION}.nupkg" \
-    --output "$ATS_NUPKG"
-
-if [ -n "${ATS_NUGET_SHA256}" ]; then
-    echo "  🔍 Verifying checksum..."
-    verify_sha256 "$ATS_NUPKG" "$ATS_NUGET_SHA256"
-fi
-
-mkdir -p "$ATS_EXTRACT"
-unzip -q "$ATS_NUPKG" -d "$ATS_EXTRACT"
-rm -f "$ATS_NUPKG"
-
-# Azure.CodeSigning.Dlib.dll is a framework-dependent .NET 8 shim — its entire
-# dependency closure (Azure.CodeSigning*.dll, Azure.Core/Identity, MSAL, Ijwhost,
-# runtimeconfig.json, VC++/MFC runtimes) ships beside it in bin/<arch> and must be
-# copied wholesale or signtool /dlib fails to load it at runtime.
-#
-# v1.0.95+ ships bin/x64 and bin/x86 only (no bin/arm64). arm64 is intentionally
-# skipped: the payload is x64-only, and placing x64 runtime DLLs (msvcp140 etc.)
-# next to the native arm64 signtool.exe would shadow its own DLL resolution and
-# break it. Azure signing on arm64 hosts uses the x64 directory instead (x64
-# signtool runs under Windows-on-ARM emulation / x64 Wine).
-ATS_ARCHS=("x86" "x64")
-ATS_REQUIRED=("Azure.CodeSigning.Dlib.dll")
-MISSING_FILES=()
-
-echo "Copying ATS payload (full bin/<arch> dependency closure)..."
-for arch in "${ATS_ARCHS[@]}"; do
-    src_dir="$ATS_EXTRACT/bin/$arch"
-    if [ ! -d "$src_dir" ]; then
-        echo "  ⚠️  Not found: $src_dir"
-        MISSING_FILES+=("$src_dir")
-        continue
-    fi
-    mkdir -p "$BUNDLE_DIR/$arch"
-    cp -R "$src_dir/." "$BUNDLE_DIR/$arch/"
-    echo "  ✅ $arch: $(ls -1 "$src_dir" | wc -l | tr -d ' ') file(s)"
-    for f in "${ATS_REQUIRED[@]}"; do
-        if [ ! -f "$BUNDLE_DIR/$arch/$f" ]; then
-            echo "  ⚠️  Not found: $src_dir/$f"
-            MISSING_FILES+=("$src_dir/$f")
-        fi
-    done
-done
-report_missing "ATS file(s)"
-
-rm -rf "$ATS_EXTRACT"
-
-# ── VERSION.txt ───────────────────────────────────────────────────────────────
+# ── ZIP ───────────────────────────────────────────────────────────────────────
 {
     echo "bundle: windows-kits"
     echo "created_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
     echo ""
     echo "version: $VERSION"
-    echo "ats_client_version: ${ATS_NUGET_VERSION}"
 } > "$BUNDLE_DIR/VERSION.txt"
 
-# ── ZIP ───────────────────────────────────────────────────────────────────────
-echo "📦 Zipping appxAssets + windows-kits..."
+echo "📦 Zipping windows-kits..."
 ASSETS_ZIP="$OUTPUT_DIR/windows-kits-bundle-${VERSION//./_}.zip"
 
 cd "$BUNDLE_DIR"
 zip -r -9 "$ASSETS_ZIP" .
+rm -rf "$BUNDLE_DIR"
 
 echo "✅ Created bundle: $ASSETS_ZIP"
 echo ""
-
-rm -rf "$BUNDLE_DIR"

--- a/packages/win-codesign/assets/build-win-kits.sh
+++ b/packages/win-codesign/assets/build-win-kits.sh
@@ -74,8 +74,10 @@ Usage: $0 [options]
                   (default: \$WINDOWS_KIT_PATH or 'C:/Program Files (x86)/Windows Kits/10/bin')
   --ats-version   Microsoft.Trusted.Signing.Client NuGet version
                   (default: \$ATS_NUGET_VERSION or '1.0.95')
-  --ats-sha256    Expected SHA-256 of the .nupkg; omit to skip verification
-                  (default: \$ATS_NUGET_SHA256)
+  --ats-sha256    Expected SHA-256 of the .nupkg. Defaults to the pinned hash of the
+                  default --ats-version; override when changing --ats-version, or pass
+                  an empty string to skip verification (not recommended)
+                  (default: \$ATS_NUGET_SHA256 or the pinned 1.0.95 hash)
   --output-dir    Output directory for the bundle ZIP
                   (default: <package-root>/out/win-codesign)
   -h|--help       Show this help
@@ -86,7 +88,8 @@ EOF
 # Defaults — CLI flags take precedence over env vars, env vars over built-in defaults
 SDK_BASE="${WINDOWS_KIT_PATH:-C:/Program Files (x86)/Windows Kits/10/bin}"
 ATS_NUGET_VERSION="${ATS_NUGET_VERSION:-1.0.95}"
-ATS_NUGET_SHA256="${ATS_NUGET_SHA256:-}"
+# Pinned SHA-256 of microsoft.trusted.signing.client.1.0.95.nupkg
+ATS_NUGET_SHA256="${ATS_NUGET_SHA256:-3bfcf1e0a3cb42af1692f0a8ed45c15de070c2de86f28a59b2795d904d8a920f}"
 OUTPUT_DIR="$SCRIPT_DIR/out/win-codesign"
 
 while [[ $# -gt 0 ]]; do
@@ -190,30 +193,39 @@ mkdir -p "$ATS_EXTRACT"
 unzip -q "$ATS_NUPKG" -d "$ATS_EXTRACT"
 rm -f "$ATS_NUPKG"
 
-# v1.0.95+ ships bin/x64 and bin/x86 only (no bin/arm64).
-# For arm64 bundles we copy the x64 binaries — Wine on arm64 Windows runs x64 DLLs.
-ATS_DLLS=(
-    "Azure.CodeSigning.Dlib.dll"
-)
+# Azure.CodeSigning.Dlib.dll is a framework-dependent .NET 8 shim — its entire
+# dependency closure (Azure.CodeSigning*.dll, Azure.Core/Identity, MSAL, Ijwhost,
+# runtimeconfig.json, VC++/MFC runtimes) ships beside it in bin/<arch> and must be
+# copied wholesale or signtool /dlib fails to load it at runtime.
+#
+# v1.0.95+ ships bin/x64 and bin/x86 only (no bin/arm64). arm64 is intentionally
+# skipped: the payload is x64-only, and placing x64 runtime DLLs (msvcp140 etc.)
+# next to the native arm64 signtool.exe would shadow its own DLL resolution and
+# break it. Azure signing on arm64 hosts uses the x64 directory instead (x64
+# signtool runs under Windows-on-ARM emulation / x64 Wine).
+ATS_ARCHS=("x86" "x64")
+ATS_REQUIRED=("Azure.CodeSigning.Dlib.dll")
 MISSING_FILES=()
 
-echo "Copying ATS DLLs..."
-for arch in "${ARCHITECTURES[@]}"; do
-    ats_src_arch="$arch"
-    [[ "$arch" == "arm64" ]] && ats_src_arch="x64"
+echo "Copying ATS payload (full bin/<arch> dependency closure)..."
+for arch in "${ATS_ARCHS[@]}"; do
+    src_dir="$ATS_EXTRACT/bin/$arch"
+    if [ ! -d "$src_dir" ]; then
+        echo "  ⚠️  Not found: $src_dir"
+        MISSING_FILES+=("$src_dir")
+        continue
+    fi
     mkdir -p "$BUNDLE_DIR/$arch"
-    for dll in "${ATS_DLLS[@]}"; do
-        src="$ATS_EXTRACT/bin/$ats_src_arch/$dll"
-        if [ -f "$src" ]; then
-            cp "$src" "$BUNDLE_DIR/$arch/$dll"
-            echo "  ✅ $arch/$dll"
-        else
-            echo "  ⚠️  Not found: $src"
-            MISSING_FILES+=("$src")
+    cp -R "$src_dir/." "$BUNDLE_DIR/$arch/"
+    echo "  ✅ $arch: $(ls -1 "$src_dir" | wc -l | tr -d ' ') file(s)"
+    for f in "${ATS_REQUIRED[@]}"; do
+        if [ ! -f "$BUNDLE_DIR/$arch/$f" ]; then
+            echo "  ⚠️  Not found: $src_dir/$f"
+            MISSING_FILES+=("$src_dir/$f")
         fi
     done
 done
-report_missing "ATS DLL(s)"
+report_missing "ATS file(s)"
 
 rm -rf "$ATS_EXTRACT"
 

--- a/packages/win-codesign/build.sh
+++ b/packages/win-codesign/build.sh
@@ -13,6 +13,8 @@ Usage: $0 [options]
   --rcedit-version    rcedit release version (default: \$RCEDIT_VERSION or '2.0.0')
   --os-target         Override OS detection: linux, darwin, windows
                       (default: auto-detected via uname)
+  --target            Windows subscript to run: ossl, kits, rcedit
+                      (repeatable; default: all three)
   -h|--help           Show this help
 EOF
     exit 1
@@ -22,6 +24,7 @@ PLATFORM_ARCH="${PLATFORM_ARCH:-x86_64}"
 OSSLSIGNCODE_VER="${OSSLSIGNCODE_VER:-2.11}"
 RCEDIT_VERSION="${RCEDIT_VERSION:-2.0.0}"
 OS_TARGET="${OS_TARGET:-}"
+TARGETS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -29,6 +32,7 @@ while [[ $# -gt 0 ]]; do
         --osslsigncode-ver) OSSLSIGNCODE_VER="$2"; shift 2 ;;
         --rcedit-version)   RCEDIT_VERSION="$2";   shift 2 ;;
         --os-target)        OS_TARGET="$2";        shift 2 ;;
+        --target)           TARGETS+=("$2");       shift 2 ;;
         -h|--help)          usage ;;
         *)                  echo "❌ Unknown argument: $1" >&2; usage ;;
     esac
@@ -56,14 +60,25 @@ elif [ "$OS_TARGET" = "darwin" ]; then
 else
     echo "Assuming Windows target."
 
+    # Default to all three when no --target flags were given
+    if [[ ${#TARGETS[@]} -eq 0 ]]; then
+        TARGETS=(ossl kits rcedit)
+    fi
+
     # must be first — install prefix wipes the output dir
-    bash "$CWD/assets/build-win-ossl.sh" \
-        --arch "${PLATFORM_ARCH}" \
-        --osslsigncode-ver "${OSSLSIGNCODE_VER}"
+    if [[ " ${TARGETS[*]} " == *" ossl "* ]]; then
+        bash "$CWD/assets/build-win-ossl.sh" \
+            --arch "${PLATFORM_ARCH}" \
+            --osslsigncode-ver "${OSSLSIGNCODE_VER}"
+    fi
 
-    bash "$CWD/assets/build-win-kits.sh"
+    if [[ " ${TARGETS[*]} " == *" kits "* ]]; then
+        bash "$CWD/assets/build-win-kits.sh"
+    fi
 
-    bash "$CWD/assets/build-win-rcedit.sh" \
-        --version "${RCEDIT_VERSION}"
+    if [[ " ${TARGETS[*]} " == *" rcedit "* ]]; then
+        bash "$CWD/assets/build-win-rcedit.sh" \
+            --version "${RCEDIT_VERSION}"
+    fi
 
 fi

--- a/packages/win-codesign/build.sh
+++ b/packages/win-codesign/build.sh
@@ -32,7 +32,12 @@ while [[ $# -gt 0 ]]; do
         --osslsigncode-ver) OSSLSIGNCODE_VER="$2"; shift 2 ;;
         --rcedit-version)   RCEDIT_VERSION="$2";   shift 2 ;;
         --os-target)        OS_TARGET="$2";        shift 2 ;;
-        --target)           TARGETS+=("$2");       shift 2 ;;
+        --target)
+            case "$2" in
+                ossl|kits|ats|rcedit) TARGETS+=("$2") ;;
+                *) echo "❌ Unknown --target value: $2 (valid: ossl, kits, ats, rcedit)" >&2; usage ;;
+            esac
+            shift 2 ;;
         -h|--help)          usage ;;
         *)                  echo "❌ Unknown argument: $1" >&2; usage ;;
     esac

--- a/packages/win-codesign/build.sh
+++ b/packages/win-codesign/build.sh
@@ -13,8 +13,8 @@ Usage: $0 [options]
   --rcedit-version    rcedit release version (default: \$RCEDIT_VERSION or '2.0.0')
   --os-target         Override OS detection: linux, darwin, windows
                       (default: auto-detected via uname)
-  --target            Windows subscript to run: ossl, kits, rcedit
-                      (repeatable; default: all three)
+  --target            Windows subscript to run: ossl, kits, ats, rcedit
+                      (repeatable; default: all four)
   -h|--help           Show this help
 EOF
     exit 1
@@ -60,9 +60,9 @@ elif [ "$OS_TARGET" = "darwin" ]; then
 else
     echo "Assuming Windows target."
 
-    # Default to all three when no --target flags were given
+    # Default to all four when no --target flags were given
     if [[ ${#TARGETS[@]} -eq 0 ]]; then
-        TARGETS=(ossl kits rcedit)
+        TARGETS=(ossl kits ats rcedit)
     fi
 
     # must be first — install prefix wipes the output dir
@@ -74,6 +74,10 @@ else
 
     if [[ " ${TARGETS[*]} " == *" kits "* ]]; then
         bash "$CWD/assets/build-win-kits.sh"
+    fi
+
+    if [[ " ${TARGETS[*]} " == *" ats "* ]]; then
+        bash "$CWD/assets/build-win-ats.sh"
     fi
 
     if [[ " ${TARGETS[*]} " == *" rcedit "* ]]; then

--- a/packages/win-codesign/test/build-win-ats-test.sh
+++ b/packages/win-codesign/test/build-win-ats-test.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Unit + e2e tests for build-win-ats.sh helpers and full script flow.
+# Run: bash packages/win-codesign/test/build-win-ats-test.sh
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../assets" && pwd)/build-win-ats.sh"
+
+# ── Minimal assertion helpers ─────────────────────────────────────────────────
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "  ✅ $desc"
+        PASS=$(( PASS + 1 ))
+    else
+        echo "  ❌ $desc"
+        echo "     expected: $(printf '%q' "$expected")"
+        echo "     actual:   $(printf '%q' "$actual")"
+        FAIL=$(( FAIL + 1 ))
+    fi
+}
+
+assert_exit() {
+    local desc="$1" expected_code="$2"
+    shift 2
+    local actual_code=0
+    "$@" >/dev/null 2>&1 || actual_code=$?
+    assert_eq "$desc" "$expected_code" "$actual_code"
+}
+
+assert_file_missing() {
+    local desc="$1" path="$2"
+    if [ ! -f "$path" ]; then
+        echo "  ✅ $desc"
+        PASS=$(( PASS + 1 ))
+    else
+        echo "  ❌ $desc (unexpectedly present: $path)"
+        FAIL=$(( FAIL + 1 ))
+    fi
+}
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+# Source helpers only (main body is gated by BASH_SOURCE guard)
+# shellcheck source=../assets/build-win-ats.sh
+source "$SCRIPT"
+
+# ── verify_sha256 ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "▶ verify_sha256"
+
+TMP_FILE="$TMPDIR_ROOT/test-hash.txt"
+echo -n "hello" > "$TMP_FILE"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    HELLO_SHA256=$(sha256sum "$TMP_FILE" | awk '{print $1}')
+else
+    HELLO_SHA256=$(shasum -a 256 "$TMP_FILE" | awk '{print $1}')
+fi
+
+assert_exit "passes when hash matches"    0 verify_sha256 "$TMP_FILE" "$HELLO_SHA256"
+assert_exit "fails when hash is wrong"    1 verify_sha256 "$TMP_FILE" "0000000000000000000000000000000000000000000000000000000000000000"
+assert_exit "fails when file is missing"  1 verify_sha256 "$TMPDIR_ROOT/nonexistent.txt" "$HELLO_SHA256"
+
+# ── e2e: full script with mocked NuGet package ───────────────────────────────
+#
+# This test exercises the complete script end-to-end without network access by:
+#   1. Creating a minimal .nupkg (zip) with the expected ATS DLL paths inside.
+#   2. Injecting a fake `curl` via PATH that copies the pre-built nupkg.
+
+echo ""
+echo "▶ e2e: full script with mocked NuGet"
+
+E2E_DIR="$TMPDIR_ROOT/e2e"
+MOCK_NUPKG_DIR="$E2E_DIR/nupkg-src"
+MOCK_NUPKG="$E2E_DIR/mock.nupkg"
+FAKE_BIN="$E2E_DIR/fake-bin"
+E2E_OUT="$E2E_DIR/out"
+
+mkdir -p "$FAKE_BIN" "$E2E_OUT"
+
+# The dlib plus a sample of its dependency closure — the script must copy the
+# whole bin/<arch> directory, not just the dlib.
+ATS_FILES=(
+    "Azure.CodeSigning.Dlib.dll"
+    "Azure.CodeSigning.dll"
+    "Ijwhost.dll"
+    "Azure.CodeSigning.Dlib.runtimeconfig.json"
+    "msvcp140.dll"
+)
+
+# Build mock nupkg mirroring real package: only x64 and x86 (no arm64 bin).
+NUPKG_ARCHS=("x86" "x64")
+for arch in "${NUPKG_ARCHS[@]}"; do
+    mkdir -p "$MOCK_NUPKG_DIR/bin/$arch"
+    for dll in "${ATS_FILES[@]}"; do
+        echo "mock-$dll" > "$MOCK_NUPKG_DIR/bin/$arch/$dll"
+    done
+done
+(cd "$MOCK_NUPKG_DIR" && zip -r -q "$MOCK_NUPKG" .)
+
+# Compute hash of the mock nupkg (exercises verification against a known-good hash)
+if command -v sha256sum >/dev/null 2>&1; then
+    MOCK_NUPKG_SHA256=$(sha256sum "$MOCK_NUPKG" | awk '{print $1}')
+else
+    MOCK_NUPKG_SHA256=$(shasum -a 256 "$MOCK_NUPKG" | awk '{print $1}')
+fi
+
+# Fake curl: ignores all flags, copies pre-built nupkg to --output path
+cat > "$FAKE_BIN/curl" << 'FAKE_CURL'
+#!/usr/bin/env bash
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output|-o) OUTPUT="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+cp "$MOCK_NUPKG_PATH" "$OUTPUT"
+FAKE_CURL
+chmod +x "$FAKE_BIN/curl"
+
+# Run the script
+E2E_EXIT=0
+E2E_OUTPUT=$(
+    MOCK_NUPKG_PATH="$MOCK_NUPKG" \
+    PATH="$FAKE_BIN:$PATH" \
+    ATS_NUGET_VERSION="0.0.0" \
+    ATS_NUGET_SHA256="$MOCK_NUPKG_SHA256" \
+    bash "$SCRIPT" --output-dir "$E2E_OUT" 2>&1
+) || E2E_EXIT=$?
+
+assert_eq "e2e: script exits 0" "0" "$E2E_EXIT"
+
+PRODUCED_ZIP=$(find "$E2E_OUT" -name "ats-bundle-*.zip" 2>/dev/null | head -1)
+
+if [ -n "$PRODUCED_ZIP" ]; then
+    echo "  ✅ e2e: output ZIP created ($PRODUCED_ZIP)"
+    PASS=$(( PASS + 1 ))
+
+    ZIP_LIST=$(unzip -l "$PRODUCED_ZIP" 2>/dev/null)
+
+    # Full ATS dependency closure in x86 and x64 (not just the dlib)
+    for arch in "${NUPKG_ARCHS[@]}"; do
+        for f in "${ATS_FILES[@]}"; do
+            if echo "$ZIP_LIST" | grep -q "$arch/$f"; then
+                echo "  ✅ e2e: ZIP contains $arch/$f"
+                PASS=$(( PASS + 1 ))
+            else
+                echo "  ❌ e2e: ZIP missing $arch/$f"
+                FAIL=$(( FAIL + 1 ))
+            fi
+        done
+    done
+
+    # arm64 must NOT carry the x64 ATS payload (would shadow native signtool DLLs)
+    for f in "Azure.CodeSigning.Dlib.dll" "msvcp140.dll"; do
+        if echo "$ZIP_LIST" | grep -q "arm64/$f"; then
+            echo "  ❌ e2e: ZIP unexpectedly contains arm64/$f"
+            FAIL=$(( FAIL + 1 ))
+        else
+            echo "  ✅ e2e: ZIP excludes arm64/$f"
+            PASS=$(( PASS + 1 ))
+        fi
+    done
+
+    if echo "$ZIP_LIST" | grep -q "VERSION.txt"; then
+        echo "  ✅ e2e: ZIP contains VERSION.txt"
+        PASS=$(( PASS + 1 ))
+    else
+        echo "  ❌ e2e: ZIP missing VERSION.txt"
+        FAIL=$(( FAIL + 1 ))
+    fi
+
+    # Verify temp files were cleaned up
+    SCRIPT_PARENT="$(cd "$(dirname "$SCRIPT")/.." && pwd)"
+    assert_file_missing "e2e: ATS nupkg cleaned up" "$SCRIPT_PARENT/out/win-codesign/ats-client.nupkg"
+
+    rm -f "$PRODUCED_ZIP"
+else
+    echo "  ❌ e2e: expected ats-bundle-*.zip not found"
+    echo "  Script output:"
+    echo "$E2E_OUTPUT" | sed 's/^/    /'
+    FAIL=$(( FAIL + 1 ))
+fi
+
+# ── e2e: named-arg CLI ────────────────────────────────────────────────────────
+
+echo ""
+echo "▶ e2e: named-arg CLI"
+
+# --help exits 1 and prints usage
+HELP_EXIT=0
+HELP_OUT=$(bash "$SCRIPT" --help 2>&1) || HELP_EXIT=$?
+assert_eq "--help exits 1" "1" "$HELP_EXIT"
+assert_eq "--help prints Usage:" "1" "$(echo "$HELP_OUT" | grep -c 'Usage:')"
+
+# Unknown flag exits 1
+UNKNOWN_EXIT=0
+bash "$SCRIPT" --unknown-flag 2>/dev/null || UNKNOWN_EXIT=$?
+assert_eq "unknown flag exits 1" "1" "$UNKNOWN_EXIT"
+
+# --ats-version overrides ATS_NUGET_VERSION env var
+ATS_VER_OUT=$(( ATS_NUGET_VERSION="9.9.9" bash "$SCRIPT" --ats-version "1.2.3" ) 2>&1) || true
+assert_eq "--ats-version overrides env ATS_NUGET_VERSION" "0" "$(echo "$ATS_VER_OUT" | grep -c '9\.9\.9')"
+
+# ── e2e: --output-dir ─────────────────────────────────────────────────────────
+
+E2E_CUSTOM_OUT="$TMPDIR_ROOT/custom-out"
+mkdir -p "$E2E_CUSTOM_OUT"
+
+E2E_CUSTOM_EXIT=0
+(
+    MOCK_NUPKG_PATH="$MOCK_NUPKG" \
+    PATH="$FAKE_BIN:$PATH" \
+    ATS_NUGET_VERSION="0.0.0" \
+    ATS_NUGET_SHA256="$MOCK_NUPKG_SHA256" \
+    bash "$SCRIPT" --output-dir "$E2E_CUSTOM_OUT" 2>&1
+) || E2E_CUSTOM_EXIT=$?
+assert_eq "e2e: --output-dir: script exits 0" "0" "$E2E_CUSTOM_EXIT"
+
+CUSTOM_ZIP=$(find "$E2E_CUSTOM_OUT" -name "ats-bundle-*.zip" 2>/dev/null | head -1)
+if [ -n "$CUSTOM_ZIP" ]; then
+    echo "  ✅ e2e: --output-dir: ZIP written to custom location ($CUSTOM_ZIP)"
+    PASS=$(( PASS + 1 ))
+    rm -f "$CUSTOM_ZIP"
+else
+    echo "  ❌ e2e: --output-dir: ZIP not found in $E2E_CUSTOM_OUT"
+    FAIL=$(( FAIL + 1 ))
+fi
+
+# ── e2e: error paths ──────────────────────────────────────────────────────────
+
+echo ""
+echo "▶ e2e: error paths"
+
+# Wrong nupkg checksum must fail closed (the script pins a default SHA-256)
+E2E_SHA_ERR=0
+(
+    MOCK_NUPKG_PATH="$MOCK_NUPKG" \
+    PATH="$FAKE_BIN:$PATH" \
+    ATS_NUGET_VERSION="0.0.0" \
+    ATS_NUGET_SHA256="0000000000000000000000000000000000000000000000000000000000000000" \
+    bash "$SCRIPT"
+) >/dev/null 2>&1 || E2E_SHA_ERR=$?
+assert_eq "exits 1 when nupkg checksum mismatches" "1" "$E2E_SHA_ERR"
+
+# ── Results ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "═══════════════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed"
+echo "═══════════════════════════════════════"
+[ "$FAIL" -eq 0 ]

--- a/packages/win-codesign/test/build-win-kits-test.sh
+++ b/packages/win-codesign/test/build-win-kits-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Unit + e2e tests for build-win-kits.sh helpers, named-arg parsing, and full script flow.
+# Unit + e2e tests for build-win-kits.sh helpers and full script flow.
 # Run: bash packages/win-codesign/test/build-win-kits-test.sh
 set -uo pipefail
 
@@ -41,17 +41,6 @@ assert_file_exists() {
     fi
 }
 
-assert_file_missing() {
-    local desc="$1" path="$2"
-    if [ ! -f "$path" ]; then
-        echo "  ✅ $desc"
-        PASS=$(( PASS + 1 ))
-    else
-        echo "  ❌ $desc (unexpectedly present: $path)"
-        FAIL=$(( FAIL + 1 ))
-    fi
-}
-
 # ── Setup ─────────────────────────────────────────────────────────────────────
 
 TMPDIR_ROOT=$(mktemp -d)
@@ -60,25 +49,6 @@ trap 'rm -rf "$TMPDIR_ROOT"' EXIT
 # Source helpers only (main body is gated by BASH_SOURCE guard)
 # shellcheck source=../assets/build-win-kits.sh
 source "$SCRIPT"
-
-# ── verify_sha256 ─────────────────────────────────────────────────────────────
-
-echo ""
-echo "▶ verify_sha256"
-
-TMP_FILE="$TMPDIR_ROOT/test-hash.txt"
-echo -n "hello" > "$TMP_FILE"
-
-# Compute the expected hash portably
-if command -v sha256sum >/dev/null 2>&1; then
-    HELLO_SHA256=$(sha256sum "$TMP_FILE" | awk '{print $1}')
-else
-    HELLO_SHA256=$(shasum -a 256 "$TMP_FILE" | awk '{print $1}')
-fi
-
-assert_exit "passes when hash matches"    0 verify_sha256 "$TMP_FILE" "$HELLO_SHA256"
-assert_exit "fails when hash is wrong"    1 verify_sha256 "$TMP_FILE" "0000000000000000000000000000000000000000000000000000000000000000"
-assert_exit "fails when file is missing"  1 verify_sha256 "$TMPDIR_ROOT/nonexistent.txt" "$HELLO_SHA256"
 
 # ── copy_arch_files ───────────────────────────────────────────────────────────
 
@@ -149,26 +119,19 @@ assert_eq "exits 1 when list is non-empty" "1" "$exit_code"
 output=$( ( MISSING_FILES=("x.dll"); report_missing "SDK file(s)" ) 2>&1 ) || true
 assert_eq "output contains the missing file name" "1" "$(echo "$output" | grep -c 'x.dll')"
 
-# ── e2e: full script with mocked SDK and NuGet package ───────────────────────
+# ── e2e: full script with mocked SDK ─────────────────────────────────────────
 #
-# This test exercises the complete script end-to-end without network access or
-# a real Windows SDK by:
-#   1. Building a directory tree that mirrors the Windows SDK layout.
-#   2. Creating a minimal .nupkg (zip) with the expected ATS DLL paths inside.
-#   3. Injecting a fake `curl` via PATH that copies the pre-built nupkg.
-#   4. Running the script with WINDOWS_KIT_PATH pointing at the mock SDK.
+# This test exercises the complete script end-to-end without a real Windows SDK
+# by building a directory tree that mirrors the Windows SDK layout.
 
 echo ""
-echo "▶ e2e: full script with mocked SDK and NuGet"
+echo "▶ e2e: full script with mocked SDK"
 
 E2E_DIR="$TMPDIR_ROOT/e2e"
 MOCK_SDK="$E2E_DIR/sdk"
-MOCK_NUPKG_DIR="$E2E_DIR/nupkg-src"
-MOCK_NUPKG="$E2E_DIR/mock.nupkg"
-FAKE_BIN="$E2E_DIR/fake-bin"
 E2E_OUT="$E2E_DIR/out"
 
-mkdir -p "$FAKE_BIN" "$E2E_OUT"
+mkdir -p "$E2E_OUT"
 
 SDK_VER="10.0.99999.0"
 ARCHS=("x86" "x64" "arm64")
@@ -183,15 +146,6 @@ SDK_FILES=(
     "Microsoft.Windows.Build.Appx.OpcServices.dll.manifest" "opcservices.dll"
     "signtool.exe" "signtool.exe.manifest" "pvk2pfx.exe"
 )
-# The dlib plus a sample of its dependency closure — the script must copy the
-# whole bin/<arch> directory, not just the dlib.
-ATS_FILES=(
-    "Azure.CodeSigning.Dlib.dll"
-    "Azure.CodeSigning.dll"
-    "Ijwhost.dll"
-    "Azure.CodeSigning.Dlib.runtimeconfig.json"
-    "msvcp140.dll"
-)
 
 # Populate mock SDK
 for arch in "${ARCHS[@]}"; do
@@ -201,67 +155,22 @@ for arch in "${ARCHS[@]}"; do
     done
 done
 
-# Build mock nupkg mirroring real package: only x64 and x86 (no arm64 bin).
-# arm64 bundles intentionally get NO ATS payload (x64 DLLs would break the
-# native arm64 signtool's DLL resolution).
-NUPKG_ARCHS=("x86" "x64")
-for arch in "${NUPKG_ARCHS[@]}"; do
-    mkdir -p "$MOCK_NUPKG_DIR/bin/$arch"
-    for dll in "${ATS_FILES[@]}"; do
-        echo "mock-$dll" > "$MOCK_NUPKG_DIR/bin/$arch/$dll"
-    done
-done
-(cd "$MOCK_NUPKG_DIR" && zip -r -q "$MOCK_NUPKG" .)
-
-# The script pins a default ATS_NUGET_SHA256; the mock nupkg has a different
-# hash, so e2e runs must pass the mock's real hash (also exercises verification).
-if command -v sha256sum >/dev/null 2>&1; then
-    MOCK_NUPKG_SHA256=$(sha256sum "$MOCK_NUPKG" | awk '{print $1}')
-else
-    MOCK_NUPKG_SHA256=$(shasum -a 256 "$MOCK_NUPKG" | awk '{print $1}')
-fi
-
-# Fake curl: ignores all flags, copies pre-built nupkg to --output path
-cat > "$FAKE_BIN/curl" << 'FAKE_CURL'
-#!/usr/bin/env bash
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --output|-o) OUTPUT="$2"; shift 2 ;;
-        *) shift ;;
-    esac
-done
-cp "$MOCK_NUPKG_PATH" "$OUTPUT"
-FAKE_CURL
-chmod +x "$FAKE_BIN/curl"
-
-# Point the script at the mock environment and run it
+# Run the script
 E2E_EXIT=0
 E2E_OUTPUT=$(
-    MOCK_NUPKG_PATH="$MOCK_NUPKG" \
-    PATH="$FAKE_BIN:$PATH" \
     WINDOWS_KIT_PATH="$MOCK_SDK" \
-    ATS_NUGET_VERSION="0.0.0" \
-    ATS_NUGET_SHA256="$MOCK_NUPKG_SHA256" \
-    bash "$SCRIPT" 2>&1
+    bash "$SCRIPT" --output-dir "$E2E_OUT" 2>&1
 ) || E2E_EXIT=$?
 
 assert_eq "e2e: script exits 0" "0" "$E2E_EXIT"
 
-# Find the produced ZIP (name contains SDK version with dots replaced by underscores)
 ZIP_VERSION="${SDK_VER//./_}"
 PRODUCED_ZIP=$(find "$E2E_OUT" -name "windows-kits-bundle-${ZIP_VERSION}.zip" 2>/dev/null | head -1)
-
-if [ -z "$PRODUCED_ZIP" ]; then
-    # Script writes to its own out/ dir; locate it relative to SCRIPT_DIR
-    SCRIPT_PARENT="$(cd "$(dirname "$SCRIPT")/.." && pwd)"
-    PRODUCED_ZIP=$(find "$SCRIPT_PARENT/out" -name "windows-kits-bundle-${ZIP_VERSION}.zip" 2>/dev/null | head -1)
-fi
 
 if [ -n "$PRODUCED_ZIP" ]; then
     echo "  ✅ e2e: output ZIP created ($PRODUCED_ZIP)"
     PASS=$(( PASS + 1 ))
 
-    # Verify expected files are inside the ZIP
     ZIP_LIST=$(unzip -l "$PRODUCED_ZIP" 2>/dev/null)
 
     # signtool.exe in every arch dir
@@ -275,30 +184,6 @@ if [ -n "$PRODUCED_ZIP" ]; then
         fi
     done
 
-    # Full ATS dependency closure in x86 and x64 (not just the dlib)
-    for arch in "${NUPKG_ARCHS[@]}"; do
-        for f in "${ATS_FILES[@]}"; do
-            if echo "$ZIP_LIST" | grep -q "$arch/$f"; then
-                echo "  ✅ e2e: ZIP contains $arch/$f"
-                PASS=$(( PASS + 1 ))
-            else
-                echo "  ❌ e2e: ZIP missing $arch/$f"
-                FAIL=$(( FAIL + 1 ))
-            fi
-        done
-    done
-
-    # arm64 must NOT carry the x64 ATS payload (would shadow native signtool DLLs)
-    for f in "Azure.CodeSigning.Dlib.dll" "msvcp140.dll"; do
-        if echo "$ZIP_LIST" | grep -q "arm64/$f"; then
-            echo "  ❌ e2e: ZIP unexpectedly contains arm64/$f"
-            FAIL=$(( FAIL + 1 ))
-        else
-            echo "  ✅ e2e: ZIP excludes arm64/$f"
-            PASS=$(( PASS + 1 ))
-        fi
-    done
-
     if echo "$ZIP_LIST" | grep -q "VERSION.txt"; then
         echo "  ✅ e2e: ZIP contains VERSION.txt"
         PASS=$(( PASS + 1 ))
@@ -307,13 +192,16 @@ if [ -n "$PRODUCED_ZIP" ]; then
         FAIL=$(( FAIL + 1 ))
     fi
 
-    # Verify temp dirs were cleaned up
-    SCRIPT_PARENT="$(cd "$(dirname "$SCRIPT")/.." && pwd)"
-    assert_file_missing "e2e: ATS nupkg cleaned up" "$SCRIPT_PARENT/out/win-codesign/ats-client.nupkg"
+    # ATS files must NOT be in the kits bundle
+    if echo "$ZIP_LIST" | grep -q "Azure.CodeSigning.Dlib.dll"; then
+        echo "  ❌ e2e: kits ZIP unexpectedly contains ATS payload"
+        FAIL=$(( FAIL + 1 ))
+    else
+        echo "  ✅ e2e: kits ZIP contains no ATS payload"
+        PASS=$(( PASS + 1 ))
+    fi
 
-    # Clean up produced output
     rm -f "$PRODUCED_ZIP"
-    rm -rf "$SCRIPT_PARENT/out/win-codesign/windows-kits-bundle"
 else
     echo "  ❌ e2e: expected ZIP not found"
     echo "  Script output:"
@@ -321,7 +209,7 @@ else
     FAIL=$(( FAIL + 1 ))
 fi
 
-# ── e2e: named-arg CLI interface ─────────────────────────────────────────────
+# ── e2e: named-arg CLI ────────────────────────────────────────────────────────
 
 echo ""
 echo "▶ e2e: named-arg CLI"
@@ -337,36 +225,11 @@ UNKNOWN_EXIT=0
 bash "$SCRIPT" --unknown-flag 2>/dev/null || UNKNOWN_EXIT=$?
 assert_eq "unknown flag exits 1" "1" "$UNKNOWN_EXIT"
 
-# --sdk-path overrides WINDOWS_KIT_PATH env var — the env-path must not appear in output
+# --sdk-path overrides WINDOWS_KIT_PATH env var
 SDK_PATH_OUT=$(( WINDOWS_KIT_PATH="/env-only-path" bash "$SCRIPT" --sdk-path "/cli-override-path" ) 2>&1) || true
 assert_eq "--sdk-path overrides env WINDOWS_KIT_PATH" "0" "$(echo "$SDK_PATH_OUT" | grep -c '/env-only-path')"
 
-# e2e: --output-dir redirects ZIP to a custom location
-E2E_CUSTOM_OUT="$TMPDIR_ROOT/custom-out"
-mkdir -p "$E2E_CUSTOM_OUT"
-
-E2E_CUSTOM_EXIT=0
-(
-    MOCK_NUPKG_PATH="$MOCK_NUPKG" \
-    PATH="$FAKE_BIN:$PATH" \
-    WINDOWS_KIT_PATH="$MOCK_SDK" \
-    ATS_NUGET_VERSION="0.0.0" \
-    ATS_NUGET_SHA256="$MOCK_NUPKG_SHA256" \
-    bash "$SCRIPT" --output-dir "$E2E_CUSTOM_OUT" 2>&1
-) || E2E_CUSTOM_EXIT=$?
-assert_eq "e2e: --output-dir: script exits 0" "0" "$E2E_CUSTOM_EXIT"
-
-CUSTOM_ZIP=$(find "$E2E_CUSTOM_OUT" -name "windows-kits-bundle-*.zip" 2>/dev/null | head -1)
-if [ -n "$CUSTOM_ZIP" ]; then
-    echo "  ✅ e2e: --output-dir: ZIP written to custom location ($CUSTOM_ZIP)"
-    PASS=$(( PASS + 1 ))
-    rm -f "$CUSTOM_ZIP"
-else
-    echo "  ❌ e2e: --output-dir: ZIP not found in $E2E_CUSTOM_OUT"
-    FAIL=$(( FAIL + 1 ))
-fi
-
-# ── e2e: missing SDK directory ────────────────────────────────────────────────
+# ── e2e: error paths ──────────────────────────────────────────────────────────
 
 echo ""
 echo "▶ e2e: error paths"
@@ -374,18 +237,6 @@ echo "▶ e2e: error paths"
 E2E_ERR=0
 ( WINDOWS_KIT_PATH="/nonexistent/path" bash "$SCRIPT" ) >/dev/null 2>&1 || E2E_ERR=$?
 assert_eq "exits 1 when SDK directory missing" "1" "$E2E_ERR"
-
-# Wrong nupkg checksum must fail closed (the script pins a default SHA-256)
-E2E_SHA_ERR=0
-(
-    MOCK_NUPKG_PATH="$MOCK_NUPKG" \
-    PATH="$FAKE_BIN:$PATH" \
-    WINDOWS_KIT_PATH="$MOCK_SDK" \
-    ATS_NUGET_VERSION="0.0.0" \
-    ATS_NUGET_SHA256="0000000000000000000000000000000000000000000000000000000000000000" \
-    bash "$SCRIPT"
-) >/dev/null 2>&1 || E2E_SHA_ERR=$?
-assert_eq "exits 1 when nupkg checksum mismatches" "1" "$E2E_SHA_ERR"
 
 # ── Results ───────────────────────────────────────────────────────────────────
 

--- a/packages/win-codesign/test/build-win-kits-test.sh
+++ b/packages/win-codesign/test/build-win-kits-test.sh
@@ -183,7 +183,15 @@ SDK_FILES=(
     "Microsoft.Windows.Build.Appx.OpcServices.dll.manifest" "opcservices.dll"
     "signtool.exe" "signtool.exe.manifest" "pvk2pfx.exe"
 )
-ATS_DLLS=("Azure.CodeSigning.Dlib.dll")
+# The dlib plus a sample of its dependency closure — the script must copy the
+# whole bin/<arch> directory, not just the dlib.
+ATS_FILES=(
+    "Azure.CodeSigning.Dlib.dll"
+    "Azure.CodeSigning.dll"
+    "Ijwhost.dll"
+    "Azure.CodeSigning.Dlib.runtimeconfig.json"
+    "msvcp140.dll"
+)
 
 # Populate mock SDK
 for arch in "${ARCHS[@]}"; do
@@ -194,15 +202,24 @@ for arch in "${ARCHS[@]}"; do
 done
 
 # Build mock nupkg mirroring real package: only x64 and x86 (no arm64 bin).
-# The script maps arm64 → x64 source when copying ATS DLLs.
+# arm64 bundles intentionally get NO ATS payload (x64 DLLs would break the
+# native arm64 signtool's DLL resolution).
 NUPKG_ARCHS=("x86" "x64")
 for arch in "${NUPKG_ARCHS[@]}"; do
     mkdir -p "$MOCK_NUPKG_DIR/bin/$arch"
-    for dll in "${ATS_DLLS[@]}"; do
+    for dll in "${ATS_FILES[@]}"; do
         echo "mock-$dll" > "$MOCK_NUPKG_DIR/bin/$arch/$dll"
     done
 done
 (cd "$MOCK_NUPKG_DIR" && zip -r -q "$MOCK_NUPKG" .)
+
+# The script pins a default ATS_NUGET_SHA256; the mock nupkg has a different
+# hash, so e2e runs must pass the mock's real hash (also exercises verification).
+if command -v sha256sum >/dev/null 2>&1; then
+    MOCK_NUPKG_SHA256=$(sha256sum "$MOCK_NUPKG" | awk '{print $1}')
+else
+    MOCK_NUPKG_SHA256=$(shasum -a 256 "$MOCK_NUPKG" | awk '{print $1}')
+fi
 
 # Fake curl: ignores all flags, copies pre-built nupkg to --output path
 cat > "$FAKE_BIN/curl" << 'FAKE_CURL'
@@ -224,6 +241,7 @@ E2E_OUTPUT=$(
     PATH="$FAKE_BIN:$PATH" \
     WINDOWS_KIT_PATH="$MOCK_SDK" \
     ATS_NUGET_VERSION="0.0.0" \
+    ATS_NUGET_SHA256="$MOCK_NUPKG_SHA256" \
     bash "$SCRIPT" 2>&1
 ) || E2E_EXIT=$?
 
@@ -245,8 +263,21 @@ if [ -n "$PRODUCED_ZIP" ]; then
 
     # Verify expected files are inside the ZIP
     ZIP_LIST=$(unzip -l "$PRODUCED_ZIP" 2>/dev/null)
+
+    # signtool.exe in every arch dir
     for arch in "${ARCHS[@]}"; do
-        for f in "signtool.exe" "Azure.CodeSigning.Dlib.dll"; do
+        if echo "$ZIP_LIST" | grep -q "$arch/signtool.exe"; then
+            echo "  ✅ e2e: ZIP contains $arch/signtool.exe"
+            PASS=$(( PASS + 1 ))
+        else
+            echo "  ❌ e2e: ZIP missing $arch/signtool.exe"
+            FAIL=$(( FAIL + 1 ))
+        fi
+    done
+
+    # Full ATS dependency closure in x86 and x64 (not just the dlib)
+    for arch in "${NUPKG_ARCHS[@]}"; do
+        for f in "${ATS_FILES[@]}"; do
             if echo "$ZIP_LIST" | grep -q "$arch/$f"; then
                 echo "  ✅ e2e: ZIP contains $arch/$f"
                 PASS=$(( PASS + 1 ))
@@ -255,6 +286,17 @@ if [ -n "$PRODUCED_ZIP" ]; then
                 FAIL=$(( FAIL + 1 ))
             fi
         done
+    done
+
+    # arm64 must NOT carry the x64 ATS payload (would shadow native signtool DLLs)
+    for f in "Azure.CodeSigning.Dlib.dll" "msvcp140.dll"; do
+        if echo "$ZIP_LIST" | grep -q "arm64/$f"; then
+            echo "  ❌ e2e: ZIP unexpectedly contains arm64/$f"
+            FAIL=$(( FAIL + 1 ))
+        else
+            echo "  ✅ e2e: ZIP excludes arm64/$f"
+            PASS=$(( PASS + 1 ))
+        fi
     done
 
     if echo "$ZIP_LIST" | grep -q "VERSION.txt"; then
@@ -309,6 +351,7 @@ E2E_CUSTOM_EXIT=0
     PATH="$FAKE_BIN:$PATH" \
     WINDOWS_KIT_PATH="$MOCK_SDK" \
     ATS_NUGET_VERSION="0.0.0" \
+    ATS_NUGET_SHA256="$MOCK_NUPKG_SHA256" \
     bash "$SCRIPT" --output-dir "$E2E_CUSTOM_OUT" 2>&1
 ) || E2E_CUSTOM_EXIT=$?
 assert_eq "e2e: --output-dir: script exits 0" "0" "$E2E_CUSTOM_EXIT"
@@ -331,6 +374,18 @@ echo "▶ e2e: error paths"
 E2E_ERR=0
 ( WINDOWS_KIT_PATH="/nonexistent/path" bash "$SCRIPT" ) >/dev/null 2>&1 || E2E_ERR=$?
 assert_eq "exits 1 when SDK directory missing" "1" "$E2E_ERR"
+
+# Wrong nupkg checksum must fail closed (the script pins a default SHA-256)
+E2E_SHA_ERR=0
+(
+    MOCK_NUPKG_PATH="$MOCK_NUPKG" \
+    PATH="$FAKE_BIN:$PATH" \
+    WINDOWS_KIT_PATH="$MOCK_SDK" \
+    ATS_NUGET_VERSION="0.0.0" \
+    ATS_NUGET_SHA256="0000000000000000000000000000000000000000000000000000000000000000" \
+    bash "$SCRIPT"
+) >/dev/null 2>&1 || E2E_SHA_ERR=$?
+assert_eq "exits 1 when nupkg checksum mismatches" "1" "$E2E_SHA_ERR"
 
 # ── Results ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Build fixes

- **Blocker — bundle the full ATS dependency closure**
  (`packages/win-codesign/assets/build-win-kits.sh`): the script copied only
  `Azure.CodeSigning.Dlib.dll` out of the `Microsoft.Trusted.Signing.Client` nupkg. The dlib
  is a thin framework-dependent .NET 8 shim — its entire dependency closure
  (`Azure.CodeSigning*.dll`, `Azure.Core`/`Azure.Identity`, MSAL
  (`Microsoft.Identity.Client*`), `Ijwhost.dll`, `Azure.CodeSigning.Dlib.runtimeconfig.json`,
  VC++/MFC runtimes — ~40 files) ships beside it in `bin/<arch>` and must be copied wholesale
  or `signtool /dlib` fails to load it at runtime. The copy is now `cp -R bin/<arch>/.` for
  x86 and x64, with a required-file assertion on the dlib.

- **arm64 kit dir no longer receives ATS DLLs**: the nupkg ships `bin/x64` and `bin/x86` only
  (verified against 1.0.95). The previous arm64→x64 single-DLL fallback is removed — dumping
  x64 runtime DLLs (`msvcp140.dll` etc.) next to the native arm64 `signtool.exe` would shadow
  its DLL resolution and break it. Azure signing on arm64 hosts instead uses the x64 kit dir
  (electron-builder side maps `arm64 → x64` for the dlib path; x64 signtool runs under
  Windows-on-ARM emulation and x64 Wine).

- **Pinned nupkg checksum**: `ATS_NUGET_SHA256` now defaults to the verified SHA-256 of
  `microsoft.trusted.signing.client.1.0.95.nupkg`
  (`3bfcf1e0a3cb42af1692f0a8ed45c15de070c2de86f28a59b2795d904d8a920f`), making verification
  fail-closed by default. Override it together with `--ats-version`, or pass an empty string
  to skip (not recommended).

- **Test coverage** (`packages/win-codesign/test/build-win-kits-test.sh`): mock nupkg now
  contains a multi-file payload; e2e asserts the full closure lands in `x86`/`x64`, that
  `arm64` carries **no** ATS payload, and that a wrong nupkg checksum fails the build.
  41 passed, 0 failed.
