### PR TITLE
feat(win-codesign): add dotnet-runtime-win-x64 bundle for Azure Trusted Signing under Wine

### DIFF
--- a/.changeset/feat-dotnet-runtime-bundle.md
+++ b/.changeset/feat-dotnet-runtime-bundle.md
@@ -1,0 +1,5 @@
+---
+"win-codesign": minor
+---
+
+feat(win-codesign): add dotnet-runtime-win-x64 bundle for Azure Trusted Signing under Wine

--- a/.github/workflows/build-wincodesign.yaml
+++ b/.github/workflows/build-wincodesign.yaml
@@ -143,6 +143,30 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  windows-dotnet:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install Wine and Xvfb
+        run: sudo apt-get install -y wine64 xvfb
+
+      - name: Build dotnet runtime bundle
+        run: bash ./packages/win-codesign/assets/build-win-dotnet.sh
+
+      - name: Run dotnet test suite (unit + Wine smoke test)
+        run: xvfb-run --auto-servernum bash ./packages/win-codesign/test/build-win-dotnet-test.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        with:
+          name: win-codesign-dotnet-runtime
+          path: ./packages/win-codesign/out/**/*.zip
+          if-no-files-found: error
+          retention-days: 1
+
   mac:
     runs-on: ${{ matrix.node }}
     timeout-minutes: 20

--- a/packages/win-codesign/assets/build-win-dotnet.sh
+++ b/packages/win-codesign/assets/build-win-dotnet.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── Helpers (sourceable for testing) ─────────────────────────────────────────
+
+verify_sha256() {
+    local file="$1" expected="$2" actual
+    if [ ! -f "$file" ]; then
+        echo "❌ File not found: $file" >&2
+        return 1
+    fi
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$file" | awk '{print $1}') || { echo "❌ sha256sum failed for $(basename "$file")" >&2; return 1; }
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$file" | awk '{print $1}') || { echo "❌ shasum failed for $(basename "$file")" >&2; return 1; }
+    else
+        echo "❌ No sha256 tool found (sha256sum or shasum required)" >&2
+        return 1
+    fi
+    if [ "$actual" = "$expected" ]; then
+        echo "  ✓ Checksum verified"
+    else
+        echo "❌ Checksum mismatch for $(basename "$file")" >&2
+        echo "   expected: $expected" >&2
+        echo "   actual:   $actual" >&2
+        return 1
+    fi
+}
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+usage() {
+    cat >&2 << EOF
+Usage: $0 [options]
+  --dotnet-version  .NET Runtime version to download
+                    (default: \$DOTNET_VERSION or '8.0.28')
+  --dotnet-sha256   Expected SHA-256 of the downloaded zip. Defaults to the pinned
+                    hash of the default --dotnet-version; override when changing
+                    --dotnet-version, or pass an empty string to skip verification
+                    (not recommended)
+                    (default: \$DOTNET_SHA256 or the pinned 8.0.28 hash)
+  --output-dir      Output directory for the bundle ZIP
+                    (default: <package-root>/out/win-codesign)
+  -h|--help         Show this help
+EOF
+    exit 1
+}
+
+# Defaults — CLI flags take precedence over env vars, env vars over built-in defaults
+DOTNET_VERSION="${DOTNET_VERSION:-8.0.28}"
+# Pinned SHA-256 of dotnet-runtime-8.0.28-win-x64.zip
+DOTNET_SHA256="${DOTNET_SHA256:-d525978009270857c7a3ff0ce7f5d1244ae547dd34482e09738fea49814f76cf}"
+OUTPUT_DIR="$SCRIPT_DIR/out/win-codesign"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dotnet-version) DOTNET_VERSION="$2"; shift 2 ;;
+        --dotnet-sha256)  DOTNET_SHA256="$2";  shift 2 ;;
+        --output-dir)     OUTPUT_DIR="$2";     shift 2 ;;
+        -h|--help)        usage ;;
+        *)                echo "❌ Unknown argument: $1" >&2; usage ;;
+    esac
+done
+
+DOTNET_ZIP="$OUTPUT_DIR/dotnet-runtime-win-x64.zip"
+DOTNET_EXTRACT="$OUTPUT_DIR/dotnet-runtime-extract"
+
+# When sourced for testing, stop here so helpers are importable without side effects.
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] || return 0
+
+# ── Cleanup on exit ───────────────────────────────────────────────────────────
+cleanup() {
+    rm -rf "$DOTNET_EXTRACT"
+    rm -f "$DOTNET_ZIP"
+}
+trap cleanup EXIT
+
+# ── Download ──────────────────────────────────────────────────────────────────
+
+DOTNET_URL="https://builds.dotnet.microsoft.com/dotnet/Runtime/${DOTNET_VERSION}/dotnet-runtime-${DOTNET_VERSION}-win-x64.zip"
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "📦 Downloading .NET Runtime v${DOTNET_VERSION} (win-x64)..."
+curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --max-time 120 \
+    "$DOTNET_URL" \
+    --output "$DOTNET_ZIP"
+
+if [ -n "${DOTNET_SHA256}" ]; then
+    echo "  🔍 Verifying checksum..."
+    verify_sha256 "$DOTNET_ZIP" "$DOTNET_SHA256"
+fi
+
+# ── Extract and repackage ─────────────────────────────────────────────────────
+# The zip layout (dotnet.exe at root, host/fxr/<ver>/, shared/Microsoft.NETCore.App/<ver>/)
+# is exactly what DOTNET_ROOT expects — repackage wholesale with a VERSION.txt injected.
+
+mkdir -p "$DOTNET_EXTRACT"
+unzip -q "$DOTNET_ZIP" -d "$DOTNET_EXTRACT"
+rm -f "$DOTNET_ZIP"
+
+REQUIRED_FILES=("dotnet.exe" "LICENSE.txt" "ThirdPartyNotices.txt")
+MISSING_FILES=()
+for f in "${REQUIRED_FILES[@]}"; do
+    if [ ! -f "$DOTNET_EXTRACT/$f" ]; then
+        echo "  ⚠️  Not found in zip: $f"
+        MISSING_FILES+=("$f")
+    fi
+done
+
+if [ "${#MISSING_FILES[@]}" -gt 0 ]; then
+    echo ""
+    echo "❌ Error: ${#MISSING_FILES[@]} expected file(s) not found in the .NET runtime zip:"
+    for f in "${MISSING_FILES[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
+
+{
+    echo "bundle: dotnet-runtime"
+    echo "created_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    echo ""
+    echo "dotnet_version: ${DOTNET_VERSION}"
+    echo "arch: win-x64"
+} > "$DOTNET_EXTRACT/VERSION.txt"
+
+echo "📦 Zipping dotnet-runtime-win-x64 bundle..."
+OUT_ZIP="$OUTPUT_DIR/dotnet-runtime-win-x64-${DOTNET_VERSION//./_}.zip"
+
+cd "$DOTNET_EXTRACT"
+zip -r -9 "$OUT_ZIP" .
+rm -rf "$DOTNET_EXTRACT"
+
+echo "✅ Created bundle: $OUT_ZIP"
+echo ""

--- a/packages/win-codesign/build.sh
+++ b/packages/win-codesign/build.sh
@@ -34,8 +34,8 @@ while [[ $# -gt 0 ]]; do
         --os-target)        OS_TARGET="$2";        shift 2 ;;
         --target)
             case "$2" in
-                ossl|kits|ats|rcedit) TARGETS+=("$2") ;;
-                *) echo "❌ Unknown --target value: $2 (valid: ossl, kits, ats, rcedit)" >&2; usage ;;
+                ossl|kits|ats|dotnet|rcedit) TARGETS+=("$2") ;;
+                *) echo "❌ Unknown --target value: $2 (valid: ossl, kits, ats, dotnet, rcedit)" >&2; usage ;;
             esac
             shift 2 ;;
         -h|--help)          usage ;;
@@ -67,7 +67,7 @@ else
 
     # Default to all four when no --target flags were given
     if [[ ${#TARGETS[@]} -eq 0 ]]; then
-        TARGETS=(ossl kits ats rcedit)
+        TARGETS=(ossl kits ats dotnet rcedit)
     fi
 
     # must be first — install prefix wipes the output dir
@@ -83,6 +83,10 @@ else
 
     if [[ " ${TARGETS[*]} " == *" ats "* ]]; then
         bash "$CWD/assets/build-win-ats.sh"
+    fi
+
+    if [[ " ${TARGETS[*]} " == *" dotnet "* ]]; then
+        bash "$CWD/assets/build-win-dotnet.sh"
     fi
 
     if [[ " ${TARGETS[*]} " == *" rcedit "* ]]; then

--- a/packages/win-codesign/test/build-win-dotnet-test.sh
+++ b/packages/win-codesign/test/build-win-dotnet-test.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# Unit + e2e + Wine smoke tests for build-win-dotnet.sh.
+# Run: bash packages/win-codesign/test/build-win-dotnet-test.sh
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../assets" && pwd)/build-win-dotnet.sh"
+PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── Minimal assertion helpers ─────────────────────────────────────────────────
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "  ✅ $desc"
+        PASS=$(( PASS + 1 ))
+    else
+        echo "  ❌ $desc"
+        echo "     expected: $(printf '%q' "$expected")"
+        echo "     actual:   $(printf '%q' "$actual")"
+        FAIL=$(( FAIL + 1 ))
+    fi
+}
+
+assert_exit() {
+    local desc="$1" expected_code="$2"
+    shift 2
+    local actual_code=0
+    "$@" >/dev/null 2>&1 || actual_code=$?
+    assert_eq "$desc" "$expected_code" "$actual_code"
+}
+
+skip() {
+    echo "  [SKIP] $*"
+    SKIP=$(( SKIP + 1 ))
+}
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+# Source helpers only (main body is gated by BASH_SOURCE guard)
+# shellcheck source=../assets/build-win-dotnet.sh
+source "$SCRIPT"
+
+# ── verify_sha256 ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "▶ verify_sha256"
+
+TMP_FILE="$TMPDIR_ROOT/test-hash.txt"
+echo -n "hello" > "$TMP_FILE"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    HELLO_SHA256=$(sha256sum "$TMP_FILE" | awk '{print $1}')
+else
+    HELLO_SHA256=$(shasum -a 256 "$TMP_FILE" | awk '{print $1}')
+fi
+
+assert_exit "passes when hash matches"    0 verify_sha256 "$TMP_FILE" "$HELLO_SHA256"
+assert_exit "fails when hash is wrong"    1 verify_sha256 "$TMP_FILE" "0000000000000000000000000000000000000000000000000000000000000000"
+assert_exit "fails when file is missing"  1 verify_sha256 "$TMPDIR_ROOT/nonexistent.txt" "$HELLO_SHA256"
+
+# ── e2e: full script with mocked download ─────────────────────────────────────
+#
+# Exercises the complete script end-to-end without network access by:
+#   1. Creating a minimal zip mirroring the real .NET runtime layout.
+#   2. Injecting a fake `curl` via PATH that copies the pre-built zip.
+
+echo ""
+echo "▶ e2e: full script with mocked download"
+
+E2E_DIR="$TMPDIR_ROOT/e2e"
+MOCK_ZIP_SRC="$E2E_DIR/dotnet-src"
+MOCK_ZIP="$E2E_DIR/mock-dotnet.zip"
+FAKE_BIN="$E2E_DIR/fake-bin"
+E2E_OUT="$E2E_DIR/out"
+
+mkdir -p "$FAKE_BIN" "$E2E_OUT"
+
+# Minimal layout mirroring the real win-x64 runtime zip
+mkdir -p "$MOCK_ZIP_SRC/host/fxr/8.0.28"
+mkdir -p "$MOCK_ZIP_SRC/shared/Microsoft.NETCore.App/8.0.28"
+echo "mock-dotnet-exe"       > "$MOCK_ZIP_SRC/dotnet.exe"
+echo "mock-license"          > "$MOCK_ZIP_SRC/LICENSE.txt"
+echo "mock-third-party"      > "$MOCK_ZIP_SRC/ThirdPartyNotices.txt"
+echo "mock-hostfxr"          > "$MOCK_ZIP_SRC/host/fxr/8.0.28/hostfxr.dll"
+echo "mock-coreclr"          > "$MOCK_ZIP_SRC/shared/Microsoft.NETCore.App/8.0.28/coreclr.dll"
+
+(cd "$MOCK_ZIP_SRC" && zip -r -q "$MOCK_ZIP" .)
+
+if command -v sha256sum >/dev/null 2>&1; then
+    MOCK_SHA256=$(sha256sum "$MOCK_ZIP" | awk '{print $1}')
+else
+    MOCK_SHA256=$(shasum -a 256 "$MOCK_ZIP" | awk '{print $1}')
+fi
+
+# Fake curl: ignores all flags, copies pre-built zip to --output path
+cat > "$FAKE_BIN/curl" << 'FAKE_CURL'
+#!/usr/bin/env bash
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output|-o) OUTPUT="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+cp "$MOCK_DOTNET_ZIP" "$OUTPUT"
+FAKE_CURL
+chmod +x "$FAKE_BIN/curl"
+
+E2E_EXIT=0
+E2E_OUTPUT=$(
+    MOCK_DOTNET_ZIP="$MOCK_ZIP" \
+    PATH="$FAKE_BIN:$PATH" \
+    DOTNET_VERSION="0.0.0" \
+    DOTNET_SHA256="$MOCK_SHA256" \
+    bash "$SCRIPT" --output-dir "$E2E_OUT" 2>&1
+) || E2E_EXIT=$?
+
+assert_eq "e2e: script exits 0" "0" "$E2E_EXIT"
+
+PRODUCED_ZIP=$(find "$E2E_OUT" -name "dotnet-runtime-win-x64-*.zip" 2>/dev/null | head -1)
+
+if [ -n "$PRODUCED_ZIP" ]; then
+    echo "  ✅ e2e: output ZIP created ($PRODUCED_ZIP)"
+    PASS=$(( PASS + 1 ))
+
+    ZIP_LIST=$(unzip -l "$PRODUCED_ZIP" 2>/dev/null)
+
+    for f in "dotnet.exe" "LICENSE.txt" "ThirdPartyNotices.txt" "VERSION.txt"; do
+        if echo "$ZIP_LIST" | grep -q "$f"; then
+            echo "  ✅ e2e: ZIP contains $f"
+            PASS=$(( PASS + 1 ))
+        else
+            echo "  ❌ e2e: ZIP missing $f"
+            FAIL=$(( FAIL + 1 ))
+        fi
+    done
+
+    if echo "$ZIP_LIST" | grep -q "host/fxr"; then
+        echo "  ✅ e2e: ZIP contains host/fxr directory"
+        PASS=$(( PASS + 1 ))
+    else
+        echo "  ❌ e2e: ZIP missing host/fxr directory"
+        FAIL=$(( FAIL + 1 ))
+    fi
+
+    if echo "$ZIP_LIST" | grep -q "shared/Microsoft.NETCore.App"; then
+        echo "  ✅ e2e: ZIP contains shared/Microsoft.NETCore.App directory"
+        PASS=$(( PASS + 1 ))
+    else
+        echo "  ❌ e2e: ZIP missing shared/Microsoft.NETCore.App directory"
+        FAIL=$(( FAIL + 1 ))
+    fi
+
+    # VERSION.txt must record the requested version
+    VERSION_CONTENTS=$(unzip -p "$PRODUCED_ZIP" VERSION.txt 2>/dev/null || true)
+    if echo "$VERSION_CONTENTS" | grep -q "dotnet_version: 0.0.0"; then
+        echo "  ✅ e2e: VERSION.txt records dotnet_version"
+        PASS=$(( PASS + 1 ))
+    else
+        echo "  ❌ e2e: VERSION.txt missing or wrong dotnet_version"
+        FAIL=$(( FAIL + 1 ))
+    fi
+
+    rm -f "$PRODUCED_ZIP"
+else
+    echo "  ❌ e2e: expected dotnet-runtime-win-x64-*.zip not found"
+    echo "  Script output:"
+    echo "$E2E_OUTPUT" | sed 's/^/    /'
+    FAIL=$(( FAIL + 1 ))
+fi
+
+# ── e2e: named-arg CLI ────────────────────────────────────────────────────────
+
+echo ""
+echo "▶ e2e: named-arg CLI"
+
+HELP_EXIT=0
+HELP_OUT=$(bash "$SCRIPT" --help 2>&1) || HELP_EXIT=$?
+assert_eq "--help exits 1" "1" "$HELP_EXIT"
+assert_eq "--help prints Usage:" "1" "$(echo "$HELP_OUT" | grep -c 'Usage:')"
+
+UNKNOWN_EXIT=0
+bash "$SCRIPT" --unknown-flag 2>/dev/null || UNKNOWN_EXIT=$?
+assert_eq "unknown flag exits 1" "1" "$UNKNOWN_EXIT"
+
+# ── e2e: --output-dir ─────────────────────────────────────────────────────────
+
+E2E_CUSTOM_OUT="$TMPDIR_ROOT/custom-out"
+mkdir -p "$E2E_CUSTOM_OUT"
+
+E2E_CUSTOM_EXIT=0
+(
+    MOCK_DOTNET_ZIP="$MOCK_ZIP" \
+    PATH="$FAKE_BIN:$PATH" \
+    DOTNET_VERSION="0.0.0" \
+    DOTNET_SHA256="$MOCK_SHA256" \
+    bash "$SCRIPT" --output-dir "$E2E_CUSTOM_OUT" 2>&1
+) || E2E_CUSTOM_EXIT=$?
+assert_eq "e2e: --output-dir: script exits 0" "0" "$E2E_CUSTOM_EXIT"
+
+CUSTOM_ZIP=$(find "$E2E_CUSTOM_OUT" -name "dotnet-runtime-win-x64-*.zip" 2>/dev/null | head -1)
+if [ -n "$CUSTOM_ZIP" ]; then
+    echo "  ✅ e2e: --output-dir: ZIP written to custom location"
+    PASS=$(( PASS + 1 ))
+    rm -f "$CUSTOM_ZIP"
+else
+    echo "  ❌ e2e: --output-dir: ZIP not found in $E2E_CUSTOM_OUT"
+    FAIL=$(( FAIL + 1 ))
+fi
+
+# ── e2e: error paths ──────────────────────────────────────────────────────────
+
+echo ""
+echo "▶ e2e: error paths"
+
+E2E_SHA_ERR=0
+(
+    MOCK_DOTNET_ZIP="$MOCK_ZIP" \
+    PATH="$FAKE_BIN:$PATH" \
+    DOTNET_VERSION="0.0.0" \
+    DOTNET_SHA256="0000000000000000000000000000000000000000000000000000000000000000" \
+    bash "$SCRIPT"
+) >/dev/null 2>&1 || E2E_SHA_ERR=$?
+assert_eq "exits 1 when checksum mismatches" "1" "$E2E_SHA_ERR"
+
+# Missing required file (dotnet.exe absent) → script exits 1
+MOCK_INCOMPLETE_SRC="$TMPDIR_ROOT/incomplete-src"
+MOCK_INCOMPLETE_ZIP="$TMPDIR_ROOT/incomplete.zip"
+mkdir -p "$MOCK_INCOMPLETE_SRC"
+echo "no-dotnet-exe" > "$MOCK_INCOMPLETE_SRC/LICENSE.txt"
+echo "no-dotnet-exe" > "$MOCK_INCOMPLETE_SRC/ThirdPartyNotices.txt"
+(cd "$MOCK_INCOMPLETE_SRC" && zip -r -q "$MOCK_INCOMPLETE_ZIP" .)
+
+if command -v sha256sum >/dev/null 2>&1; then
+    INCOMPLETE_SHA=$(sha256sum "$MOCK_INCOMPLETE_ZIP" | awk '{print $1}')
+else
+    INCOMPLETE_SHA=$(shasum -a 256 "$MOCK_INCOMPLETE_ZIP" | awk '{print $1}')
+fi
+
+E2E_MISSING_EXIT=0
+(
+    MOCK_DOTNET_ZIP="$MOCK_INCOMPLETE_ZIP" \
+    PATH="$FAKE_BIN:$PATH" \
+    DOTNET_VERSION="0.0.0" \
+    DOTNET_SHA256="$INCOMPLETE_SHA" \
+    bash "$SCRIPT" --output-dir "$TMPDIR_ROOT/missing-out"
+) >/dev/null 2>&1 || E2E_MISSING_EXIT=$?
+assert_eq "exits 1 when dotnet.exe missing from zip" "1" "$E2E_MISSING_EXIT"
+
+# ── Wine smoke test ───────────────────────────────────────────────────────────
+# Requires: a real bundle produced by build-win-dotnet.sh + wine in PATH + DISPLAY.
+# Skips cleanly if any prerequisite is absent.
+
+echo ""
+echo "▶ Wine smoke test"
+
+REAL_BUNDLE=$(find "$PACKAGE_DIR/out/win-codesign" -name "dotnet-runtime-win-x64-*.zip" 2>/dev/null | head -1)
+
+if [ -z "$REAL_BUNDLE" ]; then
+    skip "wine smoke test (no produced bundle — run build-win-dotnet.sh first)"
+else
+    WINE_BIN=""
+    for candidate in wine wine64; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            WINE_BIN="$candidate"
+            break
+        fi
+    done
+
+    if [ -z "$WINE_BIN" ]; then
+        skip "wine smoke test (no wine binary in PATH)"
+    else
+        # Basic sanity: can wine launch a Windows process at all?
+        WINE_SANE=0
+        timeout 20 "$WINE_BIN" cmd.exe /c exit 2>/dev/null || WINE_SANE=$?
+        if [ "$WINE_SANE" -ne 0 ]; then
+            skip "wine smoke test (wine sanity check failed — likely Rosetta/QEMU emulation)"
+        else
+            SMOKE_DOTNET="$TMPDIR_ROOT/smoke-dotnet"
+            SMOKE_PREFIX="$TMPDIR_ROOT/smoke-prefix"
+            mkdir -p "$SMOKE_DOTNET" "$SMOKE_PREFIX"
+
+            unzip -q "$REAL_BUNDLE" -d "$SMOKE_DOTNET"
+
+            # Initialize prefix (Wine needs a prefix even for console apps)
+            WINEPREFIX="$SMOKE_PREFIX" WINEARCH=win64 WINEDEBUG=-all \
+                "$WINE_BIN" wineboot --init 2>/dev/null || true
+
+            # Z: maps to host filesystem root under Wine
+            WIN_DOTNET_EXE="Z:$(echo "$SMOKE_DOTNET/dotnet.exe" | tr '/' '\\')"
+
+            SMOKE_EXIT=0
+            SMOKE_OUT=$(
+                WINEPREFIX="$SMOKE_PREFIX" WINEDEBUG=-all \
+                    "$WINE_BIN" "$WIN_DOTNET_EXE" --info 2>&1
+            ) || SMOKE_EXIT=$?
+
+            if [ "$SMOKE_EXIT" -eq 0 ] && echo "$SMOKE_OUT" | grep -qi "Microsoft.NETCore.App"; then
+                echo "  ✅ wine smoke test: dotnet --info exited 0 and reported NETCore.App runtime"
+                PASS=$(( PASS + 1 ))
+            else
+                echo "  ❌ wine smoke test: dotnet --info failed (exit=$SMOKE_EXIT)"
+                echo "$SMOKE_OUT" | head -10 | sed 's/^/     /'
+                FAIL=$(( FAIL + 1 ))
+            fi
+        fi
+    fi
+fi
+
+# ── Results ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "═══════════════════════════════════════"
+TOTAL=$(( PASS + FAIL + SKIP ))
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped ($TOTAL total)"
+echo "═══════════════════════════════════════"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
**New .NET Runtime bundling and testing:**

* Added `build-win-dotnet.sh` to automate downloading, verifying, and repackaging the Windows x64 .NET Runtime as a distributable ZIP bundle, including checksum validation and metadata injection.
* Added `build-win-dotnet-test.sh` with unit tests for helper functions, CLI and error handling coverage, and Wine-based smoke tests to verify the produced bundle works under Wine.

**Build system integration:**

* Updated `build.sh` to support a new `dotnet` target, enabling .NET Runtime bundle creation via CLI and including it in the default build targets. [[1]](diffhunk://#diff-7b019a20b2f87d7d14a5394c73fd8907b3989fc34b888b7985444b47cfe202b9L37-R38) [[2]](diffhunk://#diff-7b019a20b2f87d7d14a5394c73fd8907b3989fc34b888b7985444b47cfe202b9L70-R70) [[3]](diffhunk://#diff-7b019a20b2f87d7d14a5394c73fd8907b3989fc34b888b7985444b47cfe202b9R88-R91)

**CI/CD automation:**

* Added a new `windows-dotnet` job to `.github/workflows/build-wincodesign.yaml` to run the build and test scripts on Ubuntu, install Wine and Xvfb, and upload the resulting bundle as a build artifact.
