### PR TITLE
feat(icons): retry wasm-vips init and support space-delimitated args

### DIFF
--- a/.changeset/icons-cli-space-args.md
+++ b/.changeset/icons-cli-space-args.md
@@ -1,0 +1,11 @@
+---
+"icons": minor
+---
+
+feat(icons): icon-tool CLI accepts space-delimited arguments
+
+The CLI now parses both the space-delimited `--key value` form and the original
+concatenated `--key=value` form, so callers no longer have to build
+`--input=<path>` strings. Parsing is backward compatible — existing `--key=value`
+invocations continue to work unchanged. Values may contain spaces or `=`
+characters when passed as separate argv tokens.

--- a/.changeset/icons-wasm-memory-retry.md
+++ b/.changeset/icons-wasm-memory-retry.md
@@ -1,0 +1,20 @@
+---
+"icons": patch
+---
+
+fix(icons): retry wasm-vips init on transient "could not allocate memory" failures
+
+wasm-vips is a pthreads build, so its `WebAssembly.Memory` is `shared` with
+`initial === maximum` and V8 commits the full 1 GiB region up front (a shared
+backing store cannot grow once handed to worker threads). That size is baked into
+the wasm binary and cannot be lowered at runtime. When electron-builder spawns
+many `icon-tool.js` processes concurrently (its test suite fans icon conversions
+out in parallel), each one tries to commit its own gigabyte and memory-constrained
+CI runners — Windows in particular — refuse the allocation with
+`WebAssembly.Memory(): could not allocate memory`.
+
+The failures are transient: each conversion is short-lived, so a process that
+briefly backs off gets its memory once peers finish and decommit. Vips
+initialization now retries on memory-allocation errors with exponential backoff
+and full jitter (to decorrelate concurrent processes' retries). Non-allocation
+errors propagate immediately so real bugs are never masked.

--- a/packages/icons/assets/src/args.ts
+++ b/packages/icons/assets/src/args.ts
@@ -1,0 +1,31 @@
+// Parse CLI flags, accepting both the concatenated `--key=value` form and the
+// space-delimited `--key value` form so callers don't have to build
+// `--input=<path>` strings. Every flag this tool understands takes a value, so a
+// bare `--key` consumes the following token as its value — unless that token is
+// itself a flag, in which case the value is treated as empty (the caller-facing
+// validation in cli.ts reports the missing argument).
+export function parseArgs(argv: string[]): Record<string, string> {
+  const args: Record<string, string> = {}
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (!arg.startsWith('--')) {
+      continue
+    }
+    const eq = arg.indexOf('=')
+    if (eq !== -1) {
+      // --key=value (value may itself contain '=', so split on the first only)
+      args[arg.slice(2, eq)] = arg.slice(eq + 1)
+      continue
+    }
+    // --key value
+    const key = arg.slice(2)
+    const next = argv[i + 1]
+    if (next !== undefined && !next.startsWith('--')) {
+      args[key] = next
+      i++
+    } else {
+      args[key] = ''
+    }
+  }
+  return args
+}

--- a/packages/icons/assets/src/cli.ts
+++ b/packages/icons/assets/src/cli.ts
@@ -5,15 +5,7 @@ import { createIcns } from './icns'
 import { createIco } from './ico'
 import { createLinuxSet } from './linux'
 import { extractLargestPngFromIcns } from './icns-input'
-
-function parseArgs(argv: string[]): Record<string, string> {
-  const args: Record<string, string> = {}
-  for (const arg of argv) {
-    const m = arg.match(/^--([^=]+)=(.*)$/)
-    if (m) args[m[1]] = m[2]
-  }
-  return args
-}
+import { parseArgs } from './args'
 
 const VALID_FORMATS = ['icns', 'ico', 'set'] as const
 type Format = typeof VALID_FORMATS[number]
@@ -30,7 +22,7 @@ async function main(): Promise<void> {
   const outDir = args['out']
 
   if (!input || !format || !outDir) {
-    console.error('Usage: node icon-tool.js --input=<path> --format=<icns|ico|set> --out=<dir>')
+    console.error('Usage: node icon-tool.js --input <path> --format <icns|ico|set> --out <dir>')
     process.exit(1)
   }
 

--- a/packages/icons/assets/src/retry.ts
+++ b/packages/icons/assets/src/retry.ts
@@ -18,7 +18,7 @@
 
 export function isMemoryAllocationError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err)
-  return /could not allocate memory|out of memory|cannot allocate|WebAssembly\.Memory/i.test(message)
+  return /could not allocate memory|out of memory|cannot allocate memory/i.test(message)
 }
 
 export interface RetryOptions {
@@ -36,6 +36,7 @@ const defaultSleep = (ms: number): Promise<void> => new Promise(resolve => setTi
 // Non-allocation errors propagate immediately so real bugs are never masked.
 export async function retryOnAllocationFailure<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
   const attempts = options.attempts ?? 12
+  if (attempts < 1) throw new Error(`retryOnAllocationFailure: attempts must be >= 1 (got ${attempts})`)
   const baseDelayMs = options.baseDelayMs ?? 200
   const maxDelayMs = options.maxDelayMs ?? 2500
   const sleep = options.sleep ?? defaultSleep

--- a/packages/icons/assets/src/retry.ts
+++ b/packages/icons/assets/src/retry.ts
@@ -1,0 +1,60 @@
+// wasm-vips is a pthreads build: its WebAssembly.Memory is `shared` with
+// initial === maximum, so V8 commits the entire 1 GiB region up front (a shared
+// SharedArrayBuffer can't be relocated once it is handed to worker threads, so
+// the backing store cannot grow on demand). That 1 GiB is baked into the wasm
+// binary's memory import and cannot be lowered at runtime.
+//
+// When several icon-tool.js processes run at once (electron-builder spawns one
+// process per icon and its test suite fans these out in parallel), each one tries
+// to commit its own gigabyte. On memory-constrained CI runners — Windows in
+// particular, where commit charge is bounded by RAM + page file — the OS refuses
+// the allocation and the process dies with "WebAssembly.Memory(): could not
+// allocate memory".
+//
+// The failures are transient: each conversion is short-lived, so a process that
+// briefly backs off gets its memory once peers finish and decommit. These helpers
+// retry init with exponential backoff and full jitter to decorrelate concurrent
+// processes' retries (the AWS "full jitter" strategy).
+
+export function isMemoryAllocationError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+  return /could not allocate memory|out of memory|cannot allocate|WebAssembly\.Memory/i.test(message)
+}
+
+export interface RetryOptions {
+  attempts?: number
+  baseDelayMs?: number
+  maxDelayMs?: number
+  // Injectable for tests; default to real timers / RNG in production.
+  sleep?: (ms: number) => Promise<void>
+  random?: () => number
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+// Run `fn`, retrying only when it fails with a host memory-allocation error.
+// Non-allocation errors propagate immediately so real bugs are never masked.
+export async function retryOnAllocationFailure<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
+  const attempts = options.attempts ?? 12
+  const baseDelayMs = options.baseDelayMs ?? 200
+  const maxDelayMs = options.maxDelayMs ?? 2500
+  const sleep = options.sleep ?? defaultSleep
+  const random = options.random ?? Math.random
+
+  let lastError: unknown
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastError = err
+      if (!isMemoryAllocationError(err) || attempt === attempts - 1) {
+        throw err
+      }
+      // Full jitter: delay uniformly in [0, min(cap, base * 2^attempt)).
+      const ceiling = Math.min(maxDelayMs, baseDelayMs * 2 ** attempt)
+      await sleep(Math.floor(random() * ceiling))
+    }
+  }
+  // Unreachable: the loop either returns or throws on the final attempt.
+  throw lastError
+}

--- a/packages/icons/assets/src/vips.ts
+++ b/packages/icons/assets/src/vips.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs'
 import { join } from 'path'
+import { retryOnAllocationFailure } from './retry'
 
 // Load vips-node.js as a sidecar at runtime (NOT bundled by esbuild).
 // When bundled, vips-node.js sets ha=__filename to the bundle path, causing workers to
@@ -16,18 +17,24 @@ async function getVips(): Promise<any> {
   // by pre-reading the WASM binary and using instantiateWasm directly — the same
   // pattern resvg-wasm uses for its init. Skip optional codecs (HEIF, JXL, resvg).
   const wasmBuffer = readFileSync(join(__dirname, 'vips.wasm'))
-  vipsInstance = await VipsFactory({
-    dynamicLibraries: [],
-    instantiateWasm: (
-      imports: WebAssembly.Imports,
-      receiveInstance: (inst: WebAssembly.Instance, mod: WebAssembly.Module) => void
-    ) => {
-      WebAssembly.instantiate(wasmBuffer, imports).then(result => {
-        receiveInstance(result.instance, result.module)
-      })
-      return {}
-    },
-  })
+  // wasm-vips commits a fixed 1 GiB shared WebAssembly.Memory on init. Under
+  // concurrent invocations this can transiently exhaust the host's memory and
+  // throw "could not allocate memory"; retry with backoff until peers free up.
+  // See retry.ts for the full rationale.
+  vipsInstance = await retryOnAllocationFailure(() =>
+    VipsFactory({
+      dynamicLibraries: [],
+      instantiateWasm: (
+        imports: WebAssembly.Imports,
+        receiveInstance: (inst: WebAssembly.Instance, mod: WebAssembly.Module) => void
+      ) => {
+        WebAssembly.instantiate(wasmBuffer, imports).then(result => {
+          receiveInstance(result.instance, result.module)
+        })
+        return {}
+      },
+    })
+  )
   return vipsInstance
 }
 

--- a/packages/icons/assets/tests/e2e.ts
+++ b/packages/icons/assets/tests/e2e.ts
@@ -4,6 +4,8 @@ import { deflateSync } from 'zlib'
 import { join, dirname } from 'path'
 import { tmpdir } from 'os'
 import { parseIcns, parseIco, parsePngDimensions } from './validate'
+import { isMemoryAllocationError, retryOnAllocationFailure } from '../src/retry'
+import { parseArgs } from '../src/args'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -75,7 +77,14 @@ const TEST_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" 
 // Test runner
 // ---------------------------------------------------------------------------
 
-type Test = { name: string; run: (tmpDir: string, toolPath: string, pngFixture: string, svgFixture: string) => void }
+type Test = {
+  name: string
+  run: (tmpDir: string, toolPath: string, pngFixture: string, svgFixture: string) => void | Promise<void>
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message)
+}
 
 const tests: Test[] = []
 
@@ -85,7 +94,7 @@ tests.push({
   run(tmpDir, toolPath, pngFixture) {
     const out = join(tmpDir, 'png-icns')
     mkdirSync(out)
-    execSync(`node "${toolPath}" --input="${pngFixture}" --format=icns --out="${out}"`)
+    execSync(`node "${toolPath}" --input "${pngFixture}" --format icns --out "${out}"`)
     const file = join(out, 'icon.icns')
     if (!existsSync(file)) throw new Error('icon.icns was not created')
     const entries = parseIcns(readFileSync(file))
@@ -104,7 +113,7 @@ tests.push({
   run(tmpDir, toolPath, pngFixture) {
     const out = join(tmpDir, 'png-ico')
     mkdirSync(out)
-    execSync(`node "${toolPath}" --input="${pngFixture}" --format=ico --out="${out}"`)
+    execSync(`node "${toolPath}" --input "${pngFixture}" --format ico --out "${out}"`)
     const file = join(out, 'icon.ico')
     if (!existsSync(file)) throw new Error('icon.ico was not created')
     const sizes = parseIco(readFileSync(file))
@@ -122,7 +131,7 @@ tests.push({
   run(tmpDir, toolPath, pngFixture) {
     const out = join(tmpDir, 'png-set')
     mkdirSync(out)
-    execSync(`node "${toolPath}" --input="${pngFixture}" --format=set --out="${out}"`)
+    execSync(`node "${toolPath}" --input "${pngFixture}" --format set --out "${out}"`)
     const expectedSizes = [16, 24, 32, 48, 64, 128, 256, 512]
     for (const sz of expectedSizes) {
       const file = join(out, `${sz}x${sz}.png`)
@@ -141,7 +150,7 @@ tests.push({
   run(tmpDir, toolPath, _pngFixture, svgFixture) {
     const out = join(tmpDir, 'svg-icns')
     mkdirSync(out)
-    execSync(`node "${toolPath}" --input="${svgFixture}" --format=icns --out="${out}"`)
+    execSync(`node "${toolPath}" --input "${svgFixture}" --format icns --out "${out}"`)
     const file = join(out, 'icon.icns')
     if (!existsSync(file)) throw new Error('icon.icns from SVG was not created')
     const entries = parseIcns(readFileSync(file))
@@ -155,7 +164,7 @@ tests.push({
   run(tmpDir, toolPath, _pngFixture, svgFixture) {
     const out = join(tmpDir, 'svg-ico')
     mkdirSync(out)
-    execSync(`node "${toolPath}" --input="${svgFixture}" --format=ico --out="${out}"`)
+    execSync(`node "${toolPath}" --input "${svgFixture}" --format ico --out "${out}"`)
     const file = join(out, 'icon.ico')
     if (!existsSync(file)) throw new Error('icon.ico from SVG was not created')
     const sizes = parseIco(readFileSync(file))
@@ -169,13 +178,13 @@ tests.push({
   run(tmpDir, toolPath, pngFixture) {
     const step1 = join(tmpDir, 'icns-ico-step1')
     mkdirSync(step1)
-    execSync(`node "${toolPath}" --input="${pngFixture}" --format=icns --out="${step1}"`)
+    execSync(`node "${toolPath}" --input "${pngFixture}" --format icns --out "${step1}"`)
     const icnsFile = join(step1, 'icon.icns')
     if (!existsSync(icnsFile)) throw new Error('Step 1: icon.icns was not created')
 
     const step2 = join(tmpDir, 'icns-ico-step2')
     mkdirSync(step2)
-    execSync(`node "${toolPath}" --input="${icnsFile}" --format=ico --out="${step2}"`)
+    execSync(`node "${toolPath}" --input "${icnsFile}" --format ico --out "${step2}"`)
     const icoFile = join(step2, 'icon.ico')
     if (!existsSync(icoFile)) throw new Error('icon.ico from ICNS was not created')
     const sizes = parseIco(readFileSync(icoFile))
@@ -189,13 +198,13 @@ tests.push({
   run(tmpDir, toolPath, pngFixture) {
     const step1 = join(tmpDir, 'icns-set-step1')
     mkdirSync(step1)
-    execSync(`node "${toolPath}" --input="${pngFixture}" --format=icns --out="${step1}"`)
+    execSync(`node "${toolPath}" --input "${pngFixture}" --format icns --out "${step1}"`)
     const icnsFile = join(step1, 'icon.icns')
     if (!existsSync(icnsFile)) throw new Error('Step 1: icon.icns was not created')
 
     const step2 = join(tmpDir, 'icns-set-step2')
     mkdirSync(step2)
-    execSync(`node "${toolPath}" --input="${icnsFile}" --format=set --out="${step2}"`)
+    execSync(`node "${toolPath}" --input "${icnsFile}" --format set --out "${step2}"`)
     const expectedSizes = [16, 24, 32, 48, 64, 128, 256, 512]
     for (const sz of expectedSizes) {
       const file = join(step2, `${sz}x${sz}.png`)
@@ -209,10 +218,129 @@ tests.push({
 })
 
 // ---------------------------------------------------------------------------
+// Unit tests: WASM memory-allocation retry (retry.ts)
+// ---------------------------------------------------------------------------
+
+// Deterministic options: no real timers, fixed RNG → tests run instantly.
+const noWaitOpts = { sleep: async () => {}, random: () => 0 }
+
+// Test 8: retries a transient memory-allocation failure then succeeds
+tests.push({
+  name: 'retry: recovers from transient allocation failure',
+  async run() {
+    let calls = 0
+    const result = await retryOnAllocationFailure(async () => {
+      calls++
+      if (calls < 3) throw new Error('WebAssembly.Memory(): could not allocate memory')
+      return 'ok'
+    }, noWaitOpts)
+    assert(result === 'ok', `expected "ok", got "${result}"`)
+    assert(calls === 3, `expected 3 attempts, got ${calls}`)
+  },
+})
+
+// Test 9: gives up after the configured attempts, surfacing the last error
+tests.push({
+  name: 'retry: gives up after exhausting attempts',
+  async run() {
+    let calls = 0
+    let threw = false
+    try {
+      await retryOnAllocationFailure(async () => {
+        calls++
+        throw new Error('out of memory')
+      }, { ...noWaitOpts, attempts: 4 })
+    } catch (err) {
+      threw = true
+      assert(isMemoryAllocationError(err), 'expected a memory-allocation error to propagate')
+    }
+    assert(threw, 'expected retryOnAllocationFailure to throw after exhausting attempts')
+    assert(calls === 4, `expected 4 attempts, got ${calls}`)
+  },
+})
+
+// Test 10: does NOT retry non-allocation errors — they propagate immediately
+tests.push({
+  name: 'retry: rethrows non-allocation errors without retrying',
+  async run() {
+    let calls = 0
+    let threw = false
+    try {
+      await retryOnAllocationFailure(async () => {
+        calls++
+        throw new Error('some unrelated bug')
+      }, noWaitOpts)
+    } catch (err) {
+      threw = true
+      assert((err as Error).message === 'some unrelated bug', 'expected the original error to propagate')
+    }
+    assert(threw, 'expected the non-allocation error to be thrown')
+    assert(calls === 1, `expected exactly 1 attempt for a non-allocation error, got ${calls}`)
+  },
+})
+
+// Test 11: isMemoryAllocationError classifies messages correctly
+tests.push({
+  name: 'retry: isMemoryAllocationError classification',
+  run() {
+    assert(isMemoryAllocationError(new Error('WebAssembly.Memory(): could not allocate memory')), 'should match the observed CI error')
+    assert(isMemoryAllocationError(new Error('Out of memory')), 'should match "Out of memory"')
+    assert(!isMemoryAllocationError(new Error('ENOENT: no such file')), 'should not match unrelated errors')
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Unit tests: CLI argument parsing (args.ts)
+// ---------------------------------------------------------------------------
+
+// Test 12: space-delimited form — `--key value`
+tests.push({
+  name: 'args: parses space-delimited flags',
+  run() {
+    const args = parseArgs(['--input', '/tmp/icon.png', '--format', 'ico', '--out', '/tmp/out'])
+    assert(args.input === '/tmp/icon.png', `input: ${args.input}`)
+    assert(args.format === 'ico', `format: ${args.format}`)
+    assert(args.out === '/tmp/out', `out: ${args.out}`)
+  },
+})
+
+// Test 13: concatenated form — `--key=value` (backward compatibility)
+tests.push({
+  name: 'args: parses concatenated flags',
+  run() {
+    const args = parseArgs(['--input=/tmp/icon.png', '--format=icns', '--out=/tmp/out'])
+    assert(args.input === '/tmp/icon.png', `input: ${args.input}`)
+    assert(args.format === 'icns', `format: ${args.format}`)
+    assert(args.out === '/tmp/out', `out: ${args.out}`)
+  },
+})
+
+// Test 14: mixed forms and values containing characters that used to need escaping
+tests.push({
+  name: 'args: handles mixed forms, spaces, and "=" in values',
+  run() {
+    const args = parseArgs(['--input', '/tmp/my icons/a=b.png', '--format=set', '--out', '/out dir'])
+    assert(args.input === '/tmp/my icons/a=b.png', `input: ${args.input}`)
+    assert(args.format === 'set', `format: ${args.format}`)
+    assert(args.out === '/out dir', `out: ${args.out}`)
+  },
+})
+
+// Test 15: a flag with no value (followed by another flag) yields an empty string
+tests.push({
+  name: 'args: missing value does not swallow the next flag',
+  run() {
+    const args = parseArgs(['--input', '--format', 'ico'])
+    assert(args.input === '', `expected empty input, got: ${args.input}`)
+    assert(args.format === 'ico', `format: ${args.format}`)
+  },
+})
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
-function run(): void {
+async function run(): Promise<void> {
   // icon-tool.js is a sibling of this compiled e2e.js in the out/ directory
   const toolPath = join(dirname(process.argv[1]), 'icon-tool.js')
   if (!existsSync(toolPath)) {
@@ -232,7 +360,7 @@ function run(): void {
   let failed = 0
   for (const t of tests) {
     try {
-      t.run(tmpDir, toolPath, pngFixture, svgFixture)
+      await t.run(tmpDir, toolPath, pngFixture, svgFixture)
       console.log(`  PASS  ${t.name}`)
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err)
@@ -252,4 +380,7 @@ function run(): void {
   console.log(`All ${tests.length} tests passed.`)
 }
 
-run()
+run().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.stack || err.message : String(err))
+  process.exit(1)
+})


### PR DESCRIPTION
**CLI Improvements:**
* The CLI now accepts both space-delimited (`--key value`) and concatenated (`--key=value`) argument forms, making it easier to use and more compatible with common shell patterns. This change is backward compatible. 

**WASM Memory Allocation Robustness:**
* The initialization of `wasm-vips` (used for image processing) now automatically retries with exponential backoff and jitter on transient "could not allocate memory" errors, which often occur in CI or parallel environments. Non-memory errors are not retried, ensuring real bugs are surfaced immediately. 