### PR TITLE
fix(icons): read all ICNS frame types, fix resampling quality, and add diagnostics

### DIFF
--- a/.changeset/icons-icns-input-and-quality.md
+++ b/.changeset/icons-icns-input-and-quality.md
@@ -15,7 +15,7 @@ source failed with "Could not extract a PNG frame from ICNS file".
   produced from small sources. ICNS magic and per-entry bounds are now validated.
 - **Diagnostics:** on extraction failure the CLI now lists the frames found and
   their detected encodings (png/jp2/argb/raw), and the tool emits optional debug
-  logging via the standard `DEBUG=electron-builder:icons` convention (no new
+  logging via the standard `DEBUG=icons` convention (no new
   runtime dependency). JPEG2000/ARGB/legacy-raw frames remain undecodable by the
   bundled wasm-vips build but now produce an actionable message instead of a
   generic one.

--- a/.changeset/icons-icns-input-and-quality.md
+++ b/.changeset/icons-icns-input-and-quality.md
@@ -1,0 +1,31 @@
+---
+"icons": patch
+---
+
+fix(icons): read all ICNS frame types, fix resampling quality, and add diagnostics
+
+Fixes electron-builder#9876, where a valid single-layer .icns used as an icon
+source failed with "Could not extract a PNG frame from ICNS file".
+
+- **ICNS input (#9876):** the extractor previously inspected only 5 hard-coded
+  OSTypes (`ic08/ic09/ic10/ic13/ic14`). It now scans every parsed frame and
+  returns the largest PNG, so a .icns whose only/largest PNG lives in any type
+  (`icp4/icp5/icp6/ic07/ic11/ic12/…`) is read correctly. This also fixes a
+  round-trip bug where the tool could not read the .icns files its own writer
+  produced from small sources. ICNS magic and per-entry bounds are now validated.
+- **Diagnostics:** on extraction failure the CLI now lists the frames found and
+  their detected encodings (png/jp2/argb/raw), and the tool emits optional debug
+  logging via the standard `DEBUG=electron-builder:icons` convention (no new
+  runtime dependency). JPEG2000/ARGB/legacy-raw frames remain undecodable by the
+  bundled wasm-vips build but now produce an actionable message instead of a
+  generic one.
+- **Resampling quality:** `ico` and Linux `set` no longer upscale sources beyond
+  their native size, and all converters now preserve aspect ratio (non-square
+  sources are padded to a transparent square instead of being stretched). Square
+  sources are unchanged.
+- **ICNS output:** corrected `ic13` (256px) and `ic14` (512px) frame sizes to
+  match the Apple spec (were 512/1024), and `createIcns` now validates that its
+  input is a real PNG.
+- **wasm-vips:** `getVips()` memoizes the in-flight init promise so concurrent
+  conversions share a single 1 GiB allocation instead of each spawning their own;
+  the OOM-retry matcher recognizes more allocation-failure phrasings.

--- a/packages/icons/assets/src/cli.ts
+++ b/packages/icons/assets/src/cli.ts
@@ -4,8 +4,9 @@ import { svgToPng } from './svg'
 import { createIcns } from './icns'
 import { createIco } from './ico'
 import { createLinuxSet } from './linux'
-import { extractLargestPngFromIcns } from './icns-input'
+import { extractLargestPngFromIcns, describeIcnsEntries } from './icns-input'
 import { parseArgs } from './args'
+import { debug } from './log'
 
 const VALID_FORMATS = ['icns', 'ico', 'set'] as const
 type Format = typeof VALID_FORMATS[number]
@@ -39,6 +40,7 @@ async function main(): Promise<void> {
   mkdirSync(outDir, { recursive: true })
 
   const ext = extname(input).toLowerCase()
+  debug(`input=${input} format=${format} ext=${ext} out=${outDir}`)
   let pngBuffer: Buffer
 
   if (ext === '.svg') {
@@ -48,12 +50,16 @@ async function main(): Promise<void> {
     pngBuffer = readFileSync(input)
   } else if (ext === '.icns') {
     const icnsBuffer = readFileSync(input)
-    const extracted = extractLargestPngFromIcns(icnsBuffer)
-    if (!extracted) {
-      console.error('Could not extract a PNG frame from ICNS file')
+    const { png, entries } = extractLargestPngFromIcns(icnsBuffer)
+    if (!png) {
+      console.error(
+        `Could not extract a PNG frame from ICNS file. Frames found: [${describeIcnsEntries(entries)}]. ` +
+          `This toolset can only read PNG-encoded ICNS frames; JPEG2000, ARGB, and legacy raw frames are not supported. ` +
+          `Re-export the icon as a PNG/SVG source, or as an ICNS containing a PNG frame.`
+      )
       process.exit(1)
     }
-    pngBuffer = extracted
+    pngBuffer = png
   } else {
     console.error(`Unsupported input format "${ext}". Supported: .png, .svg, .icns`)
     process.exit(1)

--- a/packages/icons/assets/src/icns-input.ts
+++ b/packages/icons/assets/src/icns-input.ts
@@ -1,32 +1,110 @@
-// ICNS types in priority order: largest frames first.
-const PREFERRED_TYPES = ['ic10', 'ic09', 'ic14', 'ic08', 'ic13']
-const SKIP_TYPES = new Set(['info', 'TOC ', 'icnV', 'name'])
+import { isPng } from './png'
+import { debug } from './log'
 
-const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+// Non-image entries that never carry pixel data.
+const META_TYPES = new Set(['info', 'TOC ', 'icnV', 'name'])
+// Legacy 8-bit alpha masks (paired with the raw 24-bit types below).
+const MASK_TYPES = new Set(['s8mk', 'l8mk', 'h8mk', 't8mk'])
+// Legacy raw (uncompressed / RLE 24-bit or indexed) image types.
+const RAW_TYPES = new Set([
+  'ICON', 'ICN#', 'icm#', 'icm4', 'icm8', 'ics#', 'ics4', 'ics8', 'is32',
+  'icl4', 'icl8', 'il32', 'ich#', 'ich4', 'ich8', 'ih32', 'it32', 'icp4', 'icp5', 'icp6',
+])
 
-function isPng(data: Buffer): boolean {
-  return data.length >= 8 && data.subarray(0, 8).equals(PNG_MAGIC)
+const ICNS_MAGIC = 'icns'
+const JP2_BOX_MAGIC = Buffer.from([0x00, 0x00, 0x00, 0x0c, 0x6a, 0x50, 0x20, 0x20, 0x0d, 0x0a, 0x87, 0x0a])
+const J2K_CODESTREAM_MAGIC = Buffer.from([0xff, 0x4f, 0xff, 0x51])
+const ARGB_MAGIC = Buffer.from('ARGB', 'ascii')
+
+export type IcnsEncoding = 'png' | 'jp2' | 'argb' | 'raw' | 'mask' | 'meta' | 'unknown'
+
+export interface IcnsEntryInfo {
+  ostype: string
+  length: number
+  encoding: IcnsEncoding
+  width?: number
+  height?: number
 }
 
-export function extractLargestPngFromIcns(data: Buffer): Buffer | null {
-  const typeMap = new Map<string, { offset: number; length: number }>()
-  let offset = 8 // skip 8-byte ICNS file header
-  while (offset < data.length) {
-    if (offset + 8 > data.length) break
+export interface IcnsExtractResult {
+  // The largest PNG frame found in the container, or null if none is decodable.
+  png: Buffer | null
+  // Every parsed entry, for diagnostics when extraction fails.
+  entries: IcnsEntryInfo[]
+}
+
+function startsWith(data: Buffer, magic: Buffer): boolean {
+  return data.length >= magic.length && data.subarray(0, magic.length).equals(magic)
+}
+
+function classify(ostype: string, payload: Buffer): IcnsEncoding {
+  if (isPng(payload)) return 'png'
+  if (startsWith(payload, JP2_BOX_MAGIC) || startsWith(payload, J2K_CODESTREAM_MAGIC)) return 'jp2'
+  if (startsWith(payload, ARGB_MAGIC)) return 'argb'
+  if (META_TYPES.has(ostype)) return 'meta'
+  if (MASK_TYPES.has(ostype)) return 'mask'
+  if (RAW_TYPES.has(ostype)) return 'raw'
+  return 'unknown'
+}
+
+// Parse the ICNS container into a flat list of entries with detected encodings,
+// then return the largest PNG frame (by pixel width). Unlike a fixed OSType
+// allow-list, this inspects EVERY image-bearing entry, so a valid .icns whose
+// only/largest PNG lives in any type (icp4/icp5/icp6/ic07/ic08…/ic14) is found.
+// Non-PNG encodings (JPEG 2000, ARGB, legacy raw) cannot be decoded by the
+// bundled wasm-vips build and are reported via `entries` for diagnostics.
+export function extractLargestPngFromIcns(data: Buffer): IcnsExtractResult {
+  const entries: IcnsEntryInfo[] = []
+
+  if (data.length < 8 || data.toString('ascii', 0, 4) !== ICNS_MAGIC) {
+    debug('icns: not a valid ICNS container (bad magic)')
+    return { png: null, entries }
+  }
+
+  let best: { png: Buffer; width: number } | null = null
+  let offset = 8 // skip the 8-byte ICNS file header (magic + total length)
+  while (offset + 8 <= data.length) {
     const ostype = data.toString('ascii', offset, offset + 4)
     const entryLen = data.readUInt32BE(offset + 4)
-    if (entryLen < 8) break
-    if (!SKIP_TYPES.has(ostype)) {
-      typeMap.set(ostype, { offset: offset + 8, length: entryLen - 8 })
+    if (entryLen < 8) {
+      debug(`icns: stopping at offset ${offset}: invalid entry length ${entryLen}`)
+      break
     }
+    const payloadStart = offset + 8
+    const payloadEnd = offset + entryLen
+    if (payloadEnd > data.length) {
+      debug(`icns: truncated entry "${ostype}" at offset ${offset} (declares ${entryLen} bytes, ${data.length - offset} remain)`)
+      break
+    }
+    const payload = data.subarray(payloadStart, payloadEnd)
+    const encoding = classify(ostype, payload)
+    const info: IcnsEntryInfo = { ostype, length: payload.length, encoding }
+
+    if (encoding === 'png' && payload.length >= 24) {
+      info.width = payload.readUInt32BE(16)
+      info.height = payload.readUInt32BE(20)
+      if (best == null || info.width > best.width) {
+        best = { png: payload, width: info.width }
+      }
+    }
+
+    entries.push(info)
     offset += entryLen
   }
-  for (const t of PREFERRED_TYPES) {
-    const entry = typeMap.get(t)
-    if (entry) {
-      const payload = data.subarray(entry.offset, entry.offset + entry.length)
-      if (isPng(payload)) return payload
-    }
+
+  debug(`icns: parsed ${entries.length} entries [${entries.map(e => `${e.ostype}:${e.encoding}${e.width ? `:${e.width}x${e.height}` : ''}`).join(', ')}]`)
+  if (best != null) {
+    debug(`icns: selected largest PNG frame (${best.width}px)`)
+    return { png: best.png, entries }
   }
-  return null
+  debug('icns: no PNG frame found')
+  return { png: null, entries }
+}
+
+// Human-readable summary of parsed entries, used in the CLI failure message.
+export function describeIcnsEntries(entries: IcnsEntryInfo[]): string {
+  if (entries.length === 0) return 'none'
+  return entries
+    .map(e => `${e.ostype}(${e.encoding}, ${e.length}B${e.width ? `, ${e.width}x${e.height}` : ''})`)
+    .join(', ')
 }

--- a/packages/icons/assets/src/icns.ts
+++ b/packages/icons/assets/src/icns.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from 'fs'
 import { join } from 'path'
 import { resizeWithLanczos } from './vips'
+import { readPngSize } from './png'
 
 // Standard macOS ICNS entries. HiDPI entries (ic11–ic14) carry the same pixel
 // data as their standard counterparts — same render dimensions, different logical
@@ -15,8 +16,8 @@ const ICNS_ENTRIES: Array<{ osType: string; size: number }> = [
   { osType: 'ic10', size: 1024 },
   { osType: 'ic11', size: 32 },    // 16@2x
   { osType: 'ic12', size: 64 },    // 32@2x
-  { osType: 'ic13', size: 512 },   // 256@2x
-  { osType: 'ic14', size: 1024 },  // 512@2x
+  { osType: 'ic13', size: 256 },   // 128@2x
+  { osType: 'ic14', size: 512 },   // 256@2x
 ]
 
 // Pack pre-sized PNG frames into an ICNS container.
@@ -35,10 +36,16 @@ function packIcns(frames: Array<{ osType: string; png: Buffer }>): Buffer {
 }
 
 export async function createIcns(inputBuffer: Buffer, outputDir: string): Promise<void> {
-  // Determine source size from the PNG IHDR chunk to avoid upscaling
-  const sourceSize = inputBuffer.readUInt32BE(16)
+  // Determine source size from the PNG IHDR chunk to avoid upscaling. readPngSize
+  // validates the signature/IHDR so a non-PNG input fails loudly instead of being
+  // mis-sized from arbitrary bytes at offset 16.
+  const { width, height } = readPngSize(inputBuffer)
+  const sourceSize = Math.max(width, height)
 
   const entries = ICNS_ENTRIES.filter(e => e.size <= sourceSize)
+  if (entries.length === 0) {
+    throw new Error(`Source image is too small to build an ICNS (need at least 16px, got ${sourceSize}px)`)
+  }
 
   // Generate each unique pixel size once, reuse for HiDPI duplicates
   const uniqueSizes = [...new Set(entries.map(e => e.size))]

--- a/packages/icons/assets/src/ico.ts
+++ b/packages/icons/assets/src/ico.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from 'fs'
 import { join } from 'path'
 import { resizeWithLanczos } from './vips'
+import { readPngSize } from './png'
 
 const ICO_SIZES = [16, 24, 32, 48, 64, 128, 256]
 
@@ -35,8 +36,16 @@ function packIco(frames: Array<{ size: number; png: Buffer }>): Buffer {
 }
 
 export async function createIco(inputBuffer: Buffer, outputDir: string): Promise<void> {
+  // Never upscale: only emit sizes the source can supply. Fall back to the source's
+  // own size if it is smaller than the smallest standard ICO size.
+  const { width, height } = readPngSize(inputBuffer)
+  const sourceSize = Math.max(width, height)
+  const sizes = ICO_SIZES.filter(s => s <= sourceSize)
+  if (sizes.length === 0) {
+    sizes.push(sourceSize)
+  }
   const frames = await Promise.all(
-    ICO_SIZES.map(async size => ({ size, png: await resizeWithLanczos(inputBuffer, size) }))
+    sizes.map(async size => ({ size, png: await resizeWithLanczos(inputBuffer, size) }))
   )
   writeFileSync(join(outputDir, 'icon.ico'), packIco(frames))
 }

--- a/packages/icons/assets/src/linux.ts
+++ b/packages/icons/assets/src/linux.ts
@@ -1,11 +1,20 @@
 import { writeFileSync } from 'fs'
 import { join } from 'path'
 import { resizeWithLanczos } from './vips'
+import { readPngSize } from './png'
 
 const LINUX_SIZES = [16, 24, 32, 48, 64, 128, 256, 512]
 
 export async function createLinuxSet(inputBuffer: Buffer, outputDir: string): Promise<void> {
-  for (const size of LINUX_SIZES) {
+  // Never upscale: only emit sizes the source can supply (fall back to the source's
+  // own size if it is smaller than the smallest standard size).
+  const { width, height } = readPngSize(inputBuffer)
+  const sourceSize = Math.max(width, height)
+  const sizes = LINUX_SIZES.filter(s => s <= sourceSize)
+  if (sizes.length === 0) {
+    sizes.push(sourceSize)
+  }
+  for (const size of sizes) {
     const resized = await resizeWithLanczos(inputBuffer, size)
     writeFileSync(join(outputDir, `${size}x${size}.png`), resized)
   }

--- a/packages/icons/assets/src/log.ts
+++ b/packages/icons/assets/src/log.ts
@@ -1,0 +1,39 @@
+// Lightweight debug logger for the standalone icon-tool bundle.
+//
+// The bundle is intentionally dependency-free (shipped as a single Node script),
+// so instead of pulling in the `debug` package we honor the same DEBUG env-var
+// convention it uses. Enable with:
+//   DEBUG=icons   (or icons:*, or *)
+// Output goes to stderr so it never contaminates the tool's stdout.
+const NAMESPACE = 'icons'
+
+function isEnabled(): boolean {
+  const spec = process.env.DEBUG
+  if (!spec) {
+    return false
+  }
+  let result = false
+  for (const raw of spec.split(/[\s,]+/)) {
+    if (!raw) {
+      continue
+    }
+    const negate = raw.startsWith('-')
+    const pattern = negate ? raw.slice(1) : raw
+    const matches =
+      pattern === '*' ||
+      pattern === NAMESPACE ||
+      (pattern.endsWith('*') && NAMESPACE.startsWith(pattern.slice(0, -1)))
+    if (matches) {
+      result = !negate
+    }
+  }
+  return result
+}
+
+const enabled = isEnabled()
+
+export function debug(message: string): void {
+  if (enabled) {
+    process.stderr.write(`  ${NAMESPACE} ${message}\n`)
+  }
+}

--- a/packages/icons/assets/src/png.ts
+++ b/packages/icons/assets/src/png.ts
@@ -1,0 +1,15 @@
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+export function isPng(data: Buffer): boolean {
+  return data.length >= 8 && data.subarray(0, 8).equals(PNG_SIGNATURE)
+}
+
+// Read width/height from a PNG's IHDR chunk (bytes 16-23). Throws if the buffer
+// is not a structurally valid PNG so callers never silently mis-size a non-PNG
+// input (the IHDR offset is only meaningful for real PNGs).
+export function readPngSize(data: Buffer): { width: number; height: number } {
+  if (data.length < 24 || !isPng(data) || data.toString('ascii', 12, 16) !== 'IHDR') {
+    throw new Error('Input is not a valid PNG (missing signature or IHDR chunk)')
+  }
+  return { width: data.readUInt32BE(16), height: data.readUInt32BE(20) }
+}

--- a/packages/icons/assets/src/retry.ts
+++ b/packages/icons/assets/src/retry.ts
@@ -17,8 +17,19 @@
 // processes' retries (the AWS "full jitter" strategy).
 
 export function isMemoryAllocationError(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : String(err)
-  return /could not allocate memory|out of memory|cannot allocate memory/i.test(message)
+  // Include the error name so RangeError-flavored OOMs are matched by their message.
+  const message = err instanceof Error ? `${err.name}: ${err.message}` : String(err)
+  const code = (err as NodeJS.ErrnoException | undefined)?.code
+  if (code === 'ENOMEM') {
+    return true
+  }
+  // Covers the various phrasings V8/Emscripten/Node use when allocation fails:
+  // "WebAssembly.Memory(): could not allocate memory", "Out of memory",
+  // "Cannot enlarge memory arrays", "memory access out of bounds",
+  // "Array buffer allocation failed", "Aborted(OOM)", bare ENOMEM/OOM.
+  return /could not allocate memory|out of memory|cannot allocate|cannot enlarge memory|enlarge memory arrays|memory access out of bounds|array buffer allocation failed|WebAssembly\.Memory|\bENOMEM\b|\bOOM\b/i.test(
+    message
+  )
 }
 
 export interface RetryOptions {
@@ -36,7 +47,6 @@ const defaultSleep = (ms: number): Promise<void> => new Promise(resolve => setTi
 // Non-allocation errors propagate immediately so real bugs are never masked.
 export async function retryOnAllocationFailure<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
   const attempts = options.attempts ?? 12
-  if (attempts < 1) throw new Error(`retryOnAllocationFailure: attempts must be >= 1 (got ${attempts})`)
   const baseDelayMs = options.baseDelayMs ?? 200
   const maxDelayMs = options.maxDelayMs ?? 2500
   const sleep = options.sleep ?? defaultSleep

--- a/packages/icons/assets/src/vips.ts
+++ b/packages/icons/assets/src/vips.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { retryOnAllocationFailure } from './retry'
+import { debug } from './log'
 
 // Load vips-node.js as a sidecar at runtime (NOT bundled by esbuild).
 // When bundled, vips-node.js sets ha=__filename to the bundle path, causing workers to
@@ -9,19 +10,35 @@ import { retryOnAllocationFailure } from './retry'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const VipsFactory = require(join(__dirname, 'vips-node.js'))
 
-let vipsInstance: any = null
+// Memoize the in-flight init PROMISE, not the resolved instance. createIco/createIcns
+// kick off several resizeWithLanczos calls concurrently via Promise.all; if we keyed
+// on the resolved value, every one of them would see a still-null instance and spin up
+// its OWN VipsFactory — each committing a separate 1 GiB shared WebAssembly.Memory.
+// Sharing the promise guarantees exactly one init (one allocation) per process. On
+// failure we clear it so a later call can retry instead of being poisoned.
+let vipsPromise: Promise<any> | null = null
 
-async function getVips(): Promise<any> {
-  if (vipsInstance) return vipsInstance
+function getVips(): Promise<any> {
+  if (vipsPromise == null) {
+    vipsPromise = initVips().catch(err => {
+      vipsPromise = null
+      throw err
+    })
+  }
+  return vipsPromise
+}
+
+async function initVips(): Promise<any> {
   // Bypass the default Emscripten WASM loader (which fails inside esbuild bundles)
   // by pre-reading the WASM binary and using instantiateWasm directly — the same
   // pattern resvg-wasm uses for its init. Skip optional codecs (HEIF, JXL, resvg).
   const wasmBuffer = readFileSync(join(__dirname, 'vips.wasm'))
+  debug('vips: initializing wasm-vips (1 GiB shared memory)')
   // wasm-vips commits a fixed 1 GiB shared WebAssembly.Memory on init. Under
   // concurrent invocations this can transiently exhaust the host's memory and
   // throw "could not allocate memory"; retry with backoff until peers free up.
   // See retry.ts for the full rationale.
-  vipsInstance = await retryOnAllocationFailure(() =>
+  const vips = await retryOnAllocationFailure(() =>
     VipsFactory({
       dynamicLibraries: [],
       instantiateWasm: (
@@ -35,19 +52,40 @@ async function getVips(): Promise<any> {
       },
     })
   )
-  return vipsInstance
+  debug('vips: ready')
+  return vips
 }
 
-// Resize a PNG buffer to exactly targetSize×targetSize using Lanczos3 resampling.
-// Uses vips thumbnail algorithm: box-filter pre-shrink + Lanczos final stage,
-// matching the quality approach of the Go icon-converter's imaging.Lanczos.
-export async function resizeWithLanczos(pngBuffer: Buffer, targetSize: number): Promise<Buffer> {
+// Resize an image buffer to exactly targetSize×targetSize using Lanczos3 resampling
+// (vips thumbnail: box-filter pre-shrink + Lanczos final stage, matching the Go
+// icon-converter's imaging.Lanczos). The aspect ratio is preserved: a non-square
+// source is fitted inside the box and padded to a square with a transparent
+// background rather than stretched. A square source needs no padding (fast path).
+export async function resizeWithLanczos(imageBuffer: Buffer, targetSize: number): Promise<Buffer> {
   const vips = await getVips()
-  const out = vips.Image.thumbnailBuffer(pngBuffer, targetSize, {
-    height: targetSize,
-    size: vips.Size.force,
-  })
-  const result = Buffer.from(out.writeToBuffer('.png'))
-  out.delete()
-  return result
+  let thumb: any = null
+  let squared: any = null
+  let padded: any = null
+  try {
+    // Size.both fits within targetSize×targetSize preserving aspect ratio. Callers
+    // cap targetSize at the source's largest dimension, so this only downscales.
+    thumb = vips.Image.thumbnailBuffer(imageBuffer, targetSize, {
+      height: targetSize,
+      size: vips.Size.both,
+    })
+    if (thumb.width === targetSize && thumb.height === targetSize) {
+      return Buffer.from(thumb.writeToBuffer('.png'))
+    }
+    // Non-square: center on a transparent square canvas (ensure an alpha channel first).
+    squared = thumb.hasAlpha() ? thumb : thumb.bandjoin(255)
+    padded = squared.gravity('centre', targetSize, targetSize, {
+      extend: 'background',
+      background: [0, 0, 0, 0],
+    })
+    return Buffer.from(padded.writeToBuffer('.png'))
+  } finally {
+    if (padded) padded.delete()
+    if (squared && squared !== thumb) squared.delete()
+    if (thumb) thumb.delete()
+  }
 }

--- a/packages/icons/assets/tests/e2e.ts
+++ b/packages/icons/assets/tests/e2e.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'os'
 import { parseIcns, parseIco, parsePngDimensions } from './validate'
 import { isMemoryAllocationError, retryOnAllocationFailure } from '../src/retry'
 import { parseArgs } from '../src/args'
+import { extractLargestPngFromIcns } from '../src/icns-input'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -72,6 +73,28 @@ const TEST_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" 
   <rect width="100" height="100" fill="#4682dc"/>
   <circle cx="50" cy="50" r="35" fill="#ffffff" opacity="0.8"/>
 </svg>`
+
+// Build a minimal ICNS container from raw OSType frames (no resizing/deps).
+function makeIcns(frames: Array<{ ostype: string; payload: Buffer }>): Buffer {
+  const chunks: Buffer[] = []
+  for (const { ostype, payload } of frames) {
+    const hdr = Buffer.alloc(8)
+    hdr.write(ostype, 0, 'ascii')
+    hdr.writeUInt32BE(8 + payload.length, 4)
+    chunks.push(hdr, payload)
+  }
+  const body = Buffer.concat(chunks)
+  const fileHeader = Buffer.alloc(8)
+  fileHeader.write('icns', 0, 'ascii')
+  fileHeader.writeUInt32BE(8 + body.length, 4)
+  return Buffer.concat([fileHeader, body])
+}
+
+// A fake JPEG2000 box payload (signature only) — enough to exercise encoding detection.
+const FAKE_JP2 = Buffer.concat([
+  Buffer.from([0x00, 0x00, 0x00, 0x0c, 0x6a, 0x50, 0x20, 0x20, 0x0d, 0x0a, 0x87, 0x0a]),
+  Buffer.alloc(16),
+])
 
 // ---------------------------------------------------------------------------
 // Test runner
@@ -333,6 +356,100 @@ tests.push({
     const args = parseArgs(['--input', '--format', 'ico'])
     assert(args.input === '', `expected empty input, got: ${args.input}`)
     assert(args.format === 'ico', `format: ${args.format}`)
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Unit tests: ICNS frame extraction (icns-input.ts) — issue #9876
+// ---------------------------------------------------------------------------
+
+// Test 16: extracts a PNG stored in a NON-preferred OSType (the #9876 regression).
+// Before the fix, an icns whose only PNG was e.g. ic07/icp6 returned null.
+tests.push({
+  name: 'icns-extract: finds PNG in a non-preferred OSType (ic07)',
+  run() {
+    const icns = makeIcns([{ ostype: 'ic07', payload: makeSolidPng(128) }])
+    const { png, entries } = extractLargestPngFromIcns(icns)
+    assert(png !== null, 'expected a PNG to be extracted from an ic07-only icns')
+    assert(parsePngDimensions(png!).width === 128, 'extracted PNG should be 128px wide')
+    assert(entries.some(e => e.ostype === 'ic07' && e.encoding === 'png'), 'ic07 should be classified as png')
+  },
+})
+
+// Test 17: among multiple PNG frames, the largest is returned (not the first preferred).
+tests.push({
+  name: 'icns-extract: selects the largest PNG frame',
+  run() {
+    const icns = makeIcns([
+      { ostype: 'icp5', payload: makeSolidPng(32) },
+      { ostype: 'ic07', payload: makeSolidPng(128) },
+      { ostype: 'icp4', payload: makeSolidPng(16) },
+    ])
+    const { png } = extractLargestPngFromIcns(icns)
+    assert(png !== null && parsePngDimensions(png).width === 128, 'should select the 128px frame')
+  },
+})
+
+// Test 18: non-PNG frames are reported (not silently dropped) and yield png=null.
+tests.push({
+  name: 'icns-extract: reports non-PNG encodings and returns null',
+  run() {
+    const icns = makeIcns([{ ostype: 'ic08', payload: FAKE_JP2 }])
+    const { png, entries } = extractLargestPngFromIcns(icns)
+    assert(png === null, 'JP2-only icns should not yield a PNG')
+    assert(entries.some(e => e.ostype === 'ic08' && e.encoding === 'jp2'), 'ic08 should be classified as jp2')
+  },
+})
+
+// Test 19: invalid magic and truncated entries are handled without throwing.
+tests.push({
+  name: 'icns-extract: rejects bad magic and tolerates truncation',
+  run() {
+    const notIcns = extractLargestPngFromIcns(Buffer.from('not an icns file at all'))
+    assert(notIcns.png === null && notIcns.entries.length === 0, 'bad magic should yield empty result')
+
+    // Valid header + an entry whose declared length runs past EOF must not throw.
+    const truncated = Buffer.concat([
+      Buffer.from('icns'),
+      (() => { const b = Buffer.alloc(4); b.writeUInt32BE(9999, 0); return b })(),
+      Buffer.from('ic07'),
+      (() => { const b = Buffer.alloc(4); b.writeUInt32BE(9999, 0); return b })(),
+      Buffer.alloc(4),
+    ])
+    const res = extractLargestPngFromIcns(truncated)
+    assert(res.png === null, 'truncated entry should not produce a PNG')
+  },
+})
+
+// Test 20: end-to-end round-trip — a small PNG → ICNS (frames stored only in
+// non-preferred OSTypes icp4/icp5/icp6/ic07) → ICO. This is the exact path that
+// failed in #9876; it must now succeed.
+tests.push({
+  name: 'round-trip: 128px PNG → ICNS → ICO',
+  run(tmpDir, toolPath) {
+    const dir = join(tmpDir, 'roundtrip')
+    mkdirSync(dir)
+    const smallPng = join(dir, 'small.png')
+    writeFileSync(smallPng, makeSolidPng(128))
+
+    const icnsOut = join(dir, 'icns')
+    mkdirSync(icnsOut)
+    execSync(`node "${toolPath}" --input "${smallPng}" --format icns --out "${icnsOut}"`)
+    const icnsFile = join(icnsOut, 'icon.icns')
+    if (!existsSync(icnsFile)) throw new Error('icon.icns was not created from 128px source')
+    // The 128px source only yields non-preferred frames (icp4/icp5/icp6/ic07/ic11/ic12).
+    const types = parseIcns(readFileSync(icnsFile))
+    if (!types.includes('ic07')) throw new Error(`expected ic07 frame, found: ${types.join(', ')}`)
+
+    const icoOut = join(dir, 'ico')
+    mkdirSync(icoOut)
+    execSync(`node "${toolPath}" --input "${icnsFile}" --format ico --out "${icoOut}"`)
+    const icoFile = join(icoOut, 'icon.ico')
+    if (!existsSync(icoFile)) throw new Error('icon.ico was not created from the round-tripped ICNS')
+    const sizes = parseIco(readFileSync(icoFile))
+    if (sizes.length === 0) throw new Error('round-tripped ICO contains no images')
+    // No-upscale: a 128px source must not produce a 256px ICO frame.
+    if (sizes.some(s => s > 128)) throw new Error(`ICO upscaled beyond source: ${sizes.join(', ')}`)
   },
 })
 


### PR DESCRIPTION
**ICNS File Handling and Diagnostics:**
- The ICNS extractor now scans all frame types (not just five hard-coded OSTypes), returning the largest PNG frame found, ensuring compatibility with a wider range of `.icns` files and fixing issues with single-layer or round-tripped icons. Extraction failures now provide detailed diagnostics, listing all frames and their encodings, and the CLI emits actionable error messages. [[1]](diffhunk://#diff-7a053cdc4f40c696eb9bd05cf1f6b7c4d9c2fe2f0cc2e9547b9328b9cc3d9524R1-R31) [[2]](diffhunk://#diff-996a16ed68bd45218572a55173ca6db53ef6e75b1034073194d2c449cf327b03L1-R109) [[3]](diffhunk://#diff-7d5b80425895d339985849cc50371d484ee550b80827294de4c0bcf9b469f86fL7-R9) [[4]](diffhunk://#diff-7d5b80425895d339985849cc50371d484ee550b80827294de4c0bcf9b469f86fL51-R62)
- Debug logging is added throughout the tool, enabled via the `DEBUG=icons` environment variable, without introducing new runtime dependencies. [[1]](diffhunk://#diff-aa171a8b55ea34b922d33ab75286f381d3fd2b44f0bb1a25752ccb8a716d2c61R1-R39) [[2]](diffhunk://#diff-7d5b80425895d339985849cc50371d484ee550b80827294de4c0bcf9b469f86fL7-R9) [[3]](diffhunk://#diff-e304db9cf33ad674dcc65d706ceeb0936c881859648765f7150193d967888722R4)

**Image Quality and Output Improvements:**
- Icon converters for ICO and Linux sets no longer upscale images beyond their native size. Only available (or smaller) sizes are generated, and non-square sources are padded to squares instead of being stretched, preserving aspect ratio. [[1]](diffhunk://#diff-ed7da0434202437f0204b04156d78bb826667eeb7ff7a732a3f5a16ca9dc3f25R39-R48) [[2]](diffhunk://#diff-7b1e07ecffa57de4073dfa23530cfb78dcb31ef95787e337d0682d512746d71dR4-R17) [[3]](diffhunk://#diff-7a053cdc4f40c696eb9bd05cf1f6b7c4d9c2fe2f0cc2e9547b9328b9cc3d9524R1-R31)
- The ICNS output now uses correct frame sizes for `ic13` (256px) and `ic14` (512px), matching the Apple specification (previously 512/1024). The ICNS writer validates PNG input, ensuring only valid images are processed. [[1]](diffhunk://#diff-1d641113d8ec3368cc272768fba93cdaf2aa9d0599705df372175eec823f432dL18-R20) [[2]](diffhunk://#diff-1d641113d8ec3368cc272768fba93cdaf2aa9d0599705df372175eec823f432dL38-R48)

**Internal Refactoring and Robustness:**
- A new `readPngSize` utility safely reads PNG dimensions, ensuring non-PNG inputs are rejected early, preventing mis-sizing and errors in downstream processing. [[1]](diffhunk://#diff-e1c591b48673c93cea6499edbc9da3dfc6eca1a0515c373f42827b74fb0875fcR1-R15) [[2]](diffhunk://#diff-1d641113d8ec3368cc272768fba93cdaf2aa9d0599705df372175eec823f432dL38-R48) [[3]](diffhunk://#diff-ed7da0434202437f0204b04156d78bb826667eeb7ff7a732a3f5a16ca9dc3f25R39-R48) [[4]](diffhunk://#diff-7b1e07ecffa57de4073dfa23530cfb78dcb31ef95787e337d0682d512746d71dR4-R17)
- The `wasm-vips` initialization is now memoized at the promise level, ensuring only one instance (and 1 GiB memory allocation) per process, even under concurrent calls. If initialization fails, it can be retried.
- The out-of-memory (OOM) error matcher recognizes a wider range of allocation failure messages and error codes, improving reliability under memory pressure.

**Summary of Most Important Changes:**

**ICNS Extraction and Diagnostics:**
- The ICNS extractor now scans all frame types, returning the largest PNG and providing detailed diagnostics on failure, fixing compatibility with more `.icns` files. [[1]](diffhunk://#diff-7a053cdc4f40c696eb9bd05cf1f6b7c4d9c2fe2f0cc2e9547b9328b9cc3d9524R1-R31) [[2]](diffhunk://#diff-996a16ed68bd45218572a55173ca6db53ef6e75b1034073194d2c449cf327b03L1-R109)
- The CLI and tool emit actionable error messages and support debug logging via the `DEBUG=icons` environment variable. [[1]](diffhunk://#diff-aa171a8b55ea34b922d33ab75286f381d3fd2b44f0bb1a25752ccb8a716d2c61R1-R39) [[2]](diffhunk://#diff-7d5b80425895d339985849cc50371d484ee550b80827294de4c0bcf9b469f86fL7-R9)

**Image Quality and Output:**
- Icon converters (ICO, Linux set) and ICNS output no longer upscale images, preserve aspect ratio, and pad non-square sources, improving output quality. [[1]](diffhunk://#diff-ed7da0434202437f0204b04156d78bb826667eeb7ff7a732a3f5a16ca9dc3f25R39-R48) [[2]](diffhunk://#diff-7b1e07ecffa57de4073dfa23530cfb78dcb31ef95787e337d0682d512746d71dR4-R17) [[3]](diffhunk://#diff-7a053cdc4f40c696eb9bd05cf1f6b7c4d9c2fe2f0cc2e9547b9328b9cc3d9524R1-R31)
- ICNS output uses correct Apple spec frame sizes and validates PNG input. [[1]](diffhunk://#diff-1d641113d8ec3368cc272768fba93cdaf2aa9d0599705df372175eec823f432dL18-R20) [[2]](diffhunk://#diff-1d641113d8ec3368cc272768fba93cdaf2aa9d0599705df372175eec823f432dL38-R48)

**Internal Robustness:**
- Added a robust PNG dimension reader and improved OOM error detection. [[1]](diffhunk://#diff-e1c591b48673c93cea6499edbc9da3dfc6eca1a0515c373f42827b74fb0875fcR1-R15) [[2]](diffhunk://#diff-56b3fe24e401aba8e561f6de71e90dddcede93641dc0672e91c6018b5ad4a5a9L20-R32)
- Memoized `wasm-vips` initialization to avoid redundant memory allocations.