### PR TITLE
chore(icons): add `iconutil` verification to e2e test suite

### DIFF
--- a/.changeset/busy-zoos-think.md
+++ b/.changeset/busy-zoos-think.md
@@ -1,0 +1,5 @@
+---
+"icons": patch
+---
+
+chore(test): add `iconutil` to e2e test suite and migrate to macos GH runner

--- a/.github/workflows/build-icons.yaml
+++ b/.github/workflows/build-icons.yaml
@@ -5,9 +5,13 @@ on:
   workflow_call:
 
 jobs:
+  # Runs on macOS so the e2e suite's `iconutil` test executes — it converts the generated .icns back to
+  # an .iconset and asserts every standard size is present (regression guard for #9940, where the non-@2x
+  # icon_16x16.png / icon_32x32.png went missing). The bundle is deterministic JS + wasm, so building it
+  # on macOS produces the same artifact as Linux. The platform-agnostic tests run here too.
   build:
-    name: Build icons toolset
-    runs-on: ubuntu-latest
+    name: Build and validate icons toolset
+    runs-on: macos-latest
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -24,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build and test
+      - name: Build and test (includes the macOS-only iconutil validation)
         run: bash ./build.sh --target all
         shell: bash
         working-directory: ./packages/icons

--- a/packages/icons/assets/tests/e2e.ts
+++ b/packages/icons/assets/tests/e2e.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { deflateSync } from 'zlib'
 import { join, dirname } from 'path'
 import { tmpdir } from 'os'
@@ -100,9 +100,11 @@ const FAKE_JP2 = Buffer.concat([
 // Test runner
 // ---------------------------------------------------------------------------
 
+// A test may return `{ skipped: reason }` to be reported as skipped (e.g. platform-specific tooling).
+type SkipResult = { skipped: string }
 type Test = {
   name: string
-  run: (tmpDir: string, toolPath: string, pngFixture: string, svgFixture: string) => void | Promise<void>
+  run: (tmpDir: string, toolPath: string, pngFixture: string, svgFixture: string) => void | SkipResult | Promise<void | SkipResult>
 }
 
 function assert(condition: boolean, message: string): void {
@@ -122,10 +124,53 @@ tests.push({
     if (!existsSync(file)) throw new Error('icon.icns was not created')
     const entries = parseIcns(readFileSync(file))
     if (entries.length === 0) throw new Error('ICNS file contains no entries')
-    // At minimum, modern entries ic07–ic14 should be present for a 1024×1024 input
-    const required = ['ic07', 'ic08', 'ic09', 'ic10']
+    // For a 1024×1024 source, every standard entry must be present. icp4 (16px) and icp5 (32px) guard
+    // against regression #9940, where the small non-@2x sizes were dropped and the icon rendered broken
+    // in Finder/Activity Monitor list views. ic11–ic14 are the HiDPI (@2x) counterparts.
+    const required = ['icp4', 'icp5', 'ic07', 'ic08', 'ic09', 'ic10', 'ic11', 'ic12', 'ic13', 'ic14']
     for (const e of required) {
       if (!entries.includes(e)) throw new Error(`ICNS is missing entry "${e}" (found: ${entries.join(', ')})`)
+    }
+  },
+})
+
+// Test 1b: PNG → ICNS validated with macOS `iconutil` (the exact repro from issue #9940).
+// iconutil is macOS-only, so this is skipped on Linux/Windows CI; the Build Icons workflow runs it
+// in a dedicated macOS job. It converts the generated .icns back to an .iconset and asserts every
+// standard size is present — most importantly the non-@2x icon_16x16.png / icon_32x32.png that #9940
+// reported missing (which broke the icon in Finder/Activity Monitor/Trash list views).
+tests.push({
+  name: 'PNG → ICNS → iconutil iconset (all macOS sizes present)',
+  run(tmpDir, toolPath, pngFixture) {
+    if (process.platform !== 'darwin') {
+      return { skipped: 'iconutil is macOS-only' }
+    }
+    const out = join(tmpDir, 'iconutil-icns')
+    mkdirSync(out)
+    execSync(`node "${toolPath}" --input "${pngFixture}" --format icns --out "${out}"`)
+    const icnsFile = join(out, 'icon.icns')
+    if (!existsSync(icnsFile)) throw new Error('icon.icns was not created')
+
+    const iconset = join(tmpDir, 'iconutil-check.iconset')
+    execSync(`iconutil --convert iconset "${icnsFile}" --output "${iconset}"`)
+    const produced = new Set(readdirSync(iconset))
+
+    // The 10 standard macOS iconset sizes. icon_16x16.png and icon_32x32.png are the ones #9940 dropped.
+    const requiredSizes = [
+      'icon_16x16.png',
+      'icon_16x16@2x.png',
+      'icon_32x32.png',
+      'icon_32x32@2x.png',
+      'icon_128x128.png',
+      'icon_128x128@2x.png',
+      'icon_256x256.png',
+      'icon_256x256@2x.png',
+      'icon_512x512.png',
+      'icon_512x512@2x.png',
+    ]
+    const missing = requiredSizes.filter(name => !produced.has(name))
+    if (missing.length > 0) {
+      throw new Error(`iconutil iconset is missing sizes: ${missing.join(', ')} (found: ${[...produced].sort().join(', ')})`)
     }
   },
 })
@@ -475,9 +520,15 @@ async function run(): Promise<void> {
   writeFileSync(svgFixture, Buffer.from(TEST_SVG))
 
   let failed = 0
+  let skipped = 0
   for (const t of tests) {
     try {
-      await t.run(tmpDir, toolPath, pngFixture, svgFixture)
+      const result = await t.run(tmpDir, toolPath, pngFixture, svgFixture)
+      if (result && typeof result === 'object' && 'skipped' in result) {
+        console.log(`  SKIP  ${t.name} (${result.skipped})`)
+        skipped++
+        continue
+      }
       console.log(`  PASS  ${t.name}`)
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err)
@@ -494,7 +545,8 @@ async function run(): Promise<void> {
     console.error(`${failed} of ${tests.length} test(s) failed.`)
     process.exit(1)
   }
-  console.log(`All ${tests.length} tests passed.`)
+  const skipSuffix = skipped > 0 ? ` (${skipped} skipped)` : ''
+  console.log(`All ${tests.length - skipped} tests passed${skipSuffix}.`)
 }
 
 run().catch((err: unknown) => {


### PR DESCRIPTION
* Added a new end-to-end test that uses macOS's `iconutil` to verify that all standard icon sizes (including non-@2x `icon_16x16.png` and `icon_32x32.png`) are present in generated `.icns` files, directly guarding against regressions like electron-builder#9940. This test is skipped on non-macOS platforms.
* Improved test runner to support and report skipped tests, allowing platform-specific tests to be included without causing failures on other operating systems.
* Changed the `build-icons.yaml` workflow to run on `macos-latest` instead of `ubuntu-latest`, ensuring that macOS-specific tests (like `iconutil` validation) are executed in CI. The job was renamed to clarify this.
* The `.icns` test now requires all standard entries (including `icp4` and `icp5` for 16px/32px) to be present, not just the modern entries, further guarding against incomplete icon generation.