### PR TITLE
feat(wix): ship WiX Toolset v3.14.1 (candle/light)

### DIFF
--- a/.changeset/wix-v3.md
+++ b/.changeset/wix-v3.md
@@ -1,0 +1,5 @@
+---
+"wix": major
+---
+
+feat(wix): ship WiX Toolset v3.14.1 (candle/light) instead of the v4 source-compiled toolset, restoring the cross-platform candle.exe + light.exe pipeline that runs under Wine/mono for MSI and Squirrel.Windows builds

--- a/.github/workflows/build-wix.yaml
+++ b/.github/workflows/build-wix.yaml
@@ -5,21 +5,17 @@ on:
   workflow_call:
 
 jobs:
-  # Build WiX v4 from source. Requires Windows: the C++ wixnative.exe component
-  # needs MSVC, and the build entry point is a Windows batch script.
-  # build_all.cmd uses vswhere -version [17.0,18.0) to find VS 2022; windows-2022
-  # has VS 2022 (MSBuild 17.x). windows-2025 would also work today but is scheduled
-  # to redirect to windows-2025-vs2026 (VS 2026 only) on 2026-06-15, breaking the
-  # vswhere check. build.sh pins the .NET SDK to 8.x so MSBuild 17 can load it.
+  # Download the official WiX v3 binaries and repackage them. No compiler or
+  # Windows runner is needed — it is a download + checksum + repackage step.
   build:
-    name: Build (Windows source compile)
-    runs-on: windows-2022
-    timeout-minutes: 60
+    name: Build (download + repackage)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Build WiX from source
+      - name: Build WiX bundle
         shell: bash
         run: bash ./packages/wix/build.sh --target build
 
@@ -31,9 +27,9 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Smoke test on each platform. Structural checks always pass;
-  # the full Wine functional test (wix.exe build → .msi) requires
-  # .NET 6 Windows runtime in the Wine prefix (see Dockerfile notes).
+  # Smoke test on each platform. Structural checks always pass; the full
+  # functional test (candle → light → .msi) runs only on a native x86_64 host
+  # with wine-mono available (see Dockerfile notes) and skips otherwise.
   test:
     name: Test (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}

--- a/packages/wix/Dockerfile
+++ b/packages/wix/Dockerfile
@@ -6,11 +6,12 @@ ENV WINEDEBUG=-all
 # Shared prefix avoids redundant Wine initialization across test runs in the container.
 ENV WINEPREFIX=/root/.wine
 
-# Runtime notes for WiX v4:
-#   wix.exe targets net6.0 and requires the .NET 6 Windows runtime in the Wine prefix.
-#   The structural tests (file checks + wine sanity check) always pass.
-#   For the full functional test (wix.exe build → .msi), install .NET 6 in the prefix:
-#     winetricks dotnet60   (or dotnet80 — wix.exe accepts any rollforward Major runtime)
+# Runtime notes for WiX v3:
+#   candle.exe / light.exe are .NET Framework managed executables, so the Wine
+#   prefix needs wine-mono (Wine's .NET Framework implementation). The structural
+#   tests (file checks + wine sanity check) always pass. The full functional test
+#   (candle → light → .msi) runs only on a native x86_64 host with wine-mono
+#   installed; under CPU emulation (Rosetta/QEMU) it skips gracefully.
 #
 # wine32:i386 — WoW64 support for 32-bit auxiliary executables
 # xvfb        — virtual display so Wine's GUI subsystem initialises headlessly
@@ -28,8 +29,20 @@ RUN dpkg --add-architecture i386 && \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
-# Pre-initialize the Wine prefix at build time so the first `wine` call in
-# the test doesn't pay the initialization cost under the test timeout.
+# Pre-stage wine-mono so `wineboot --init` installs the .NET Framework runtime
+# offline. Ubuntu 24.04 ships wine 9.0, which expects wine-mono 9.0.0; placing
+# the matching MSI in Wine's shared mono dir makes wineboot auto-install it.
+ARG WINE_MONO_VERSION=9.0.0
+ARG WINE_MONO_SHA256=79f6c43100675566c112f4199b9ea7b944d338164b34bd91fa11b0b0a414e1c4
+RUN mkdir -p /usr/share/wine/mono && \
+    curl -fsSL --retry 3 \
+      "https://dl.winehq.org/wine/wine-mono/${WINE_MONO_VERSION}/wine-mono-${WINE_MONO_VERSION}-x86.msi" \
+      -o "/usr/share/wine/mono/wine-mono-${WINE_MONO_VERSION}-x86.msi" && \
+    echo "${WINE_MONO_SHA256}  /usr/share/wine/mono/wine-mono-${WINE_MONO_VERSION}-x86.msi" | sha256sum -c -
+
+# Pre-initialize the Wine prefix at build time (installs wine-mono from the
+# staged MSI) so the first `wine` call in the test doesn't pay the cost under
+# the test timeout.
 RUN /bin/bash -c ' \
     Xvfb :98 -screen 0 800x600x16 -nolisten tcp & XVFB_PID=$! && \
     sleep 2 && \

--- a/packages/wix/assets/test.sh
+++ b/packages/wix/assets/test.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PACKAGE_DIR="$SCRIPT_DIR/.."
 OUT_DIR="$PACKAGE_DIR/out/wix"
 
-WIX_VERSION="4.0.6"
+WIX_VERSION="3.14.1"
 ARCHIVE="$OUT_DIR/wix-${WIX_VERSION}.tar.gz"
 TEST_DIR="$(mktemp -d)"
 XVFB_PID=""
@@ -24,10 +24,11 @@ echo "PASS: Archive exists ($(du -h "$ARCHIVE" | cut -f1))"
 # 2. Extract
 tar -xzf "$ARCHIVE" -C "$TEST_DIR"
 
-# 3. Verify core tool files are present
-for f in wix.exe wix.dll WixToolset.Core.dll WixToolset.Core.Native.dll \
-          WixToolset.Core.WindowsInstaller.dll WixToolset.Data.dll \
-          WixToolset.Extensibility.dll; do
+# 3. Verify core v3 tool files are present
+for f in candle.exe candle.exe.config light.exe light.exe.config \
+          smoke.exe dark.exe heat.exe lit.exe \
+          wix.dll wix.targets winterop.dll mergemod.dll \
+          WixUIExtension.dll WixUtilExtension.dll; do
   if [ ! -f "$TEST_DIR/$f" ]; then
     echo "FAIL: Missing expected file: $f"
     exit 1
@@ -35,9 +36,8 @@ for f in wix.exe wix.dll WixToolset.Core.dll WixToolset.Core.Native.dll \
   echo "PASS: $f present"
 done
 
-# 4. Verify native assets (wixnative.exe is required for CAB creation)
-for f in "runtimes/win-x64/native/wixnative.exe" \
-          "cubes/darice.cub" "cubes/mergemod.cub"; do
+# 4. Verify native assets (cubes for ICE validation, burn bootstrapper engine)
+for f in "darice.cub" "mergemod.cub" "x86/burn.exe"; do
   if [ ! -f "$TEST_DIR/$f" ]; then
     echo "FAIL: Missing expected native asset: $f"
     exit 1
@@ -52,14 +52,18 @@ if [ ! -f "$TEST_DIR/LICENSE.TXT" ]; then
 fi
 echo "PASS: LICENSE.TXT present"
 
-# 6. Verify v3 tools are NOT present (candle/light replaced by wix.exe)
-for f in candle.exe light.exe smoke.exe; do
-  if [ -f "$TEST_DIR/$f" ]; then
-    echo "FAIL: v3 tool $f should not be in the v4 bundle"
+# 6. Verify dev-only dirs were excluded, and confirm this is v3 (no v4 wix.exe)
+for d in sdk doc; do
+  if [ -d "$TEST_DIR/$d" ]; then
+    echo "FAIL: dev-only directory '$d' should not be in the bundle"
     exit 1
   fi
 done
-echo "PASS: v3 tools absent (candle/light replaced by wix.exe)"
+if [ -f "$TEST_DIR/wix.exe" ]; then
+  echo "FAIL: wix.exe present — this should be the v3 candle/light bundle, not v4"
+  exit 1
+fi
+echo "PASS: dev-only dirs excluded (sdk/, doc/); v3 bundle confirmed (no wix.exe)"
 
 echo ""
 echo "=== Functional test via Wine ==="
@@ -82,7 +86,7 @@ fi
 echo "Using wine binary: $(command -v "$WINE_BIN") ($("$WINE_BIN" --version 2>/dev/null || echo unknown))"
 
 # Wine prefix strategy:
-#   Docker  → reuse the pre-initialized global prefix from the image build (Mono installed)
+#   Docker  → reuse the pre-initialized global prefix from the image build (wine-mono installed)
 #   macOS   → fresh temp prefix per run
 if [ -f /.dockerenv ] && [ -d /root/.wine ]; then
   export WINEPREFIX=/root/.wine
@@ -103,13 +107,17 @@ fi
 
 cp "$SCRIPT_DIR/test.wxs" "$TEST_DIR/test.wxs"
 
-# Convert Unix absolute paths to Wine Windows paths (Z: = host root)
-unix_to_wine() { echo "Z:$(echo "$1" | tr '/' '\\')"; }
+# Resolve Windows-style paths for the Wine-hosted tools. winepath is the most
+# reliable; fall back to mapping the Unix root onto the Z: drive.
+to_winpath() {
+  winepath -w "$1" 2>/dev/null || echo "Z:$(echo "$1" | tr '/' '\\')"
+}
 
-WIN_WXS=$(unix_to_wine "$TEST_DIR/test.wxs")
-WIN_MSI=$(unix_to_wine "$TEST_DIR/test.msi")
+WIN_WXS=$(to_winpath "$TEST_DIR/test.wxs")
+WIN_WIXOBJ=$(to_winpath "$TEST_DIR/test.wixobj")
+WIN_MSI=$(to_winpath "$TEST_DIR/test.msi")
 
-# Sanity-check basic Wine before attempting .NET
+# Sanity-check basic Wine before attempting .NET (candle/light are managed apps).
 echo "Running wine sanity check..."
 if ! timeout 15 "$WINE_BIN" cmd.exe /c exit 2>/dev/null; then
   echo "SKIP: basic wine cmd.exe failed — likely running under CPU emulation (Rosetta/QEMU)"
@@ -120,28 +128,36 @@ if ! timeout 15 "$WINE_BIN" cmd.exe /c exit 2>/dev/null; then
 fi
 echo "PASS: wine sanity check"
 
-# Run wix.exe build — single step replaces the v3 candle+light pipeline.
-# wix.exe targets net6.0. Under Wine, the .NET 6 Windows runtime must be
-# installed in the Wine prefix (e.g. via: winetricks dotnet60).
-# If the runtime is absent, wix.exe exits non-zero and we skip gracefully.
-echo "Running wix.exe build..."
-WIX_EXIT=0
-timeout 60 "$WINE_BIN" "$TEST_DIR/wix.exe" build "$WIN_WXS" -o "$WIN_MSI" 2>/dev/null \
-  || WIX_EXIT=$?
+# candle.exe compiles .wxs → .wixobj. candle/light are .NET Framework apps and
+# need wine-mono in the prefix; if it's absent, candle exits non-zero and we
+# skip gracefully rather than failing the structural guarantee.
+echo "Running candle.exe..."
+CANDLE_EXIT=0
+timeout 60 "$WINE_BIN" "$TEST_DIR/candle.exe" -nologo "$WIN_WXS" -o "$WIN_WIXOBJ" 2>/dev/null \
+  || CANDLE_EXIT=$?
 
-if [ ! -f "$TEST_DIR/test.msi" ]; then
-  if [ "$WIX_EXIT" -eq 124 ]; then
-    echo "SKIP: wix.exe timed out (timeout 60s)"
+if [ ! -f "$TEST_DIR/test.wixobj" ]; then
+  if [ "$CANDLE_EXIT" -eq 124 ]; then
+    echo "SKIP: candle.exe timed out (timeout 60s)"
   else
-    echo "SKIP: wix.exe exited $WIX_EXIT without producing test.msi"
+    echo "SKIP: candle.exe exited $CANDLE_EXIT without producing test.wixobj"
   fi
-  echo "      The .NET 6 Windows runtime is not installed in this Wine prefix."
-  echo "      To enable full Wine testing: winetricks dotnet60 (or dotnet80)"
+  echo "      The .NET Framework runtime (wine-mono) is not available in this Wine prefix."
   echo ""
   echo "=== Structural checks passed; functional build test skipped ==="
   exit 0
 fi
-echo "PASS: wix.exe build compiled test.wxs → test.msi"
+echo "PASS: candle.exe compiled test.wxs → test.wixobj"
+
+# light.exe links .wixobj → .msi. -sval suppresses ICE validation, which would
+# otherwise require the Windows Installer service (unavailable under Wine).
+echo "Running light.exe..."
+timeout 60 "$WINE_BIN" "$TEST_DIR/light.exe" -nologo -sval "$WIN_WIXOBJ" -o "$WIN_MSI" 2>/dev/null || true
+if [ ! -f "$TEST_DIR/test.msi" ]; then
+  echo "FAIL: light.exe did not produce test.msi"
+  exit 1
+fi
+echo "PASS: light.exe linked test.wixobj → test.msi"
 
 # Verify MSI magic bytes (OLE compound document: D0 CF 11 E0)
 MAGIC=$(xxd -l 4 -p "$TEST_DIR/test.msi")

--- a/packages/wix/assets/test.wxs
+++ b/packages/wix/assets/test.wxs
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
-  <Package Name="WixBundleTest" Manufacturer="electron-builder" Version="1.0.0.0"
-           UpgradeCode="12345678-1234-1234-1234-000000000001" Scope="perUser">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Name="WixBundleTest" Version="1.0.0.0"
+           Manufacturer="electron-builder" Language="1033"
+           UpgradeCode="12345678-1234-1234-1234-000000000001">
+    <Package InstallerVersion="200" Compressed="yes" InstallScope="perUser" />
     <MediaTemplate EmbedCab="yes" />
-    <Feature Id="ProductFeature" Title="Stub" />
-  </Package>
+    <Feature Id="ProductFeature" Title="Stub">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER" />
+  </Product>
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDER" Name="WixBundleTest" />
+      </Directory>
+    </Directory>
+  </Fragment>
 </Wix>

--- a/packages/wix/build.sh
+++ b/packages/wix/build.sh
@@ -4,20 +4,25 @@ set -euo pipefail
 # =============================================================================
 # WiX Toolset Bundle Builder
 # =============================================================================
-# Builds WiX v4 from source (wixtoolset/wix) and packages into a tar.gz.
-# Source compilation is always free under MS-RL (fee applies only to the
-# official pre-built binary releases). See OSMFEULA.txt in the source repo.
+# Downloads the official WiX v3 binaries (wixtoolset/wix3) and repackages them
+# into a tar.gz. WiX v3 ships the classic candle.exe + light.exe pipeline, which
+# runs under Wine/mono on macOS and Linux — this is what electron-builder needs
+# for cross-platform MSI and Squirrel.Windows builds. (WiX v4's single wix.exe
+# targets .NET 6 and does not run under mono.)
+#
+# The WiX v3 binaries are distributed under the MS-RL; LICENSE.TXT ships inside
+# the upstream zip and is preserved in the bundle for redistribution.
 #
 # Build order:
-#   1. build        - Compile WiX from source (Windows only — requires MSVC + .NET SDK)
+#   1. build        - Download + repackage the v3 binaries into the tar.gz
 #   2. test-mac     - Smoke test on macOS via native Wine
 #   3. test-linux   - Smoke test inside linux/amd64 Docker container via Wine
 #   4. test-all     - Run test-mac and test-linux
-#   5. all          - build + test-linux (CI default)
+#   5. all          - build + tests (CI default)
 #
 # Platform requirements:
-#   build:       windows-2025 GitHub Actions runner (Visual Studio + MSVC + .NET SDK)
-#   test-mac:    wine in PATH (brew install wine-stable)
+#   build:       any host with curl, unzip, rsync, tar (no compiler needed)
+#   test-mac:    wine in PATH (brew install --cask wine-stable)
 #   test-linux:  Docker
 # =============================================================================
 
@@ -25,9 +30,10 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ASSETS_DIR="$SCRIPT_DIR/assets"
 OUT_DIR="$SCRIPT_DIR/out/wix"
 
-WIX_VERSION="4.0.6"
-WIX_TAG="v4.0.6"
-WIX_REPO="https://github.com/wixtoolset/wix.git"
+WIX_VERSION="3.14.1"
+WIX_TAG="wix3141rtm"
+WIX_ZIP_URL="https://github.com/wixtoolset/wix3/releases/download/${WIX_TAG}/wix314-binaries.zip"
+WIX_SHA256="6ac824e1642d6f7277d0ed7ea09411a508f6116ba6fae0aa5f2c7daa2ff43d31"
 ARCHIVE_NAME="wix-${WIX_VERSION}.tar.gz"
 
 DOCKER_IMAGE="wix-builder"
@@ -49,99 +55,57 @@ print_banner() {
     echo ""
 }
 
-build_bundle() {
-    echo "Building WiX ${WIX_VERSION} from source..."
-    echo ""
-
-    # This target requires Windows — Visual Studio C++ tools and .NET SDK must be present.
-    # On GitHub Actions, use the windows-2025 runner which has VS 2026 pre-installed.
-    if [[ "${RUNNER_OS:-}" != "Windows" ]] && [[ "${OS:-}" != "Windows_NT" ]]; then
-        echo "❌ --target build requires a Windows environment."
-        echo "   WiX v4 source compilation needs Visual Studio C++ tools (wixnative.exe)"
-        echo "   and the .NET SDK. Use the windows-2025 GitHub Actions runner."
-        echo ""
-        echo "   To test an existing artifact: --target test-mac or --target test-linux"
+# Portable SHA-256 verification (sha256sum on Linux, shasum -a 256 on macOS).
+verify_sha256() {
+    local file="$1" expected="$2" actual
+    if command -v sha256sum &>/dev/null; then
+        actual="$(sha256sum "$file" | cut -d' ' -f1)"
+    elif command -v shasum &>/dev/null; then
+        actual="$(shasum -a 256 "$file" | cut -d' ' -f1)"
+    else
+        echo "❌ no sha256 tool found (need sha256sum or shasum)"
         exit 1
     fi
+    if [ "$actual" != "$expected" ]; then
+        echo "❌ checksum mismatch for $(basename "$file")"
+        echo "   expected: $expected"
+        echo "   actual:   $actual"
+        exit 1
+    fi
+}
+
+build_bundle() {
+    echo "Downloading WiX ${WIX_VERSION} binaries..."
+    echo ""
 
     local SRC_DIR
     SRC_DIR="$(mktemp -d)"
 
-    mkdir -p "$OUT_DIR"
+    mkdir -p "$OUT_DIR" "$SRC_DIR/extract" "$SRC_DIR/bundle"
 
-    echo "  Cloning wixtoolset/wix ${WIX_TAG}..."
-    git clone --depth=1 --branch "$WIX_TAG" "$WIX_REPO" "$SRC_DIR/wix"
+    echo "  Fetching ${WIX_ZIP_URL}"
+    curl -fsSL --retry 3 "$WIX_ZIP_URL" -o "$SRC_DIR/wix.zip"
 
-    # WiX generates its global.json from this template during build_init.cmd.
-    # The template's "sdk" block only sets allowPrerelease:false with NO version
-    # pin, so .NET picks the highest installed SDK (10.x on the runner). .NET SDK
-    # 10 requires MSBuild 18, but the v143 C++ toolset WiX needs only ships with
-    # VS 2022 (MSBuild 17). Pin the SDK to 8.x so MSBuild 17 can load it. This
-    # preserves the template's msbuild-sdks pins (Traversal, NoTargets).
-    echo "  Pinning .NET SDK to 8.x in global.json template..."
-    local GLOBAL_JSON_PP="$SRC_DIR/wix/src/internal/SetBuildNumber/global.json.pp"
-    sed -i.bak 's/"allowPrerelease": false/"version": "8.0.100",\n    "rollForward": "latestFeature",\n    "allowPrerelease": false/' \
-        "$GLOBAL_JSON_PP"
+    echo "  Verifying SHA-256..."
+    verify_sha256 "$SRC_DIR/wix.zip" "$WIX_SHA256"
 
-    # Pre-create wixnative intermediate directories to avoid RC1109 on windows-2022:
-    # parallel MSBuild sometimes invokes RC.exe before the IntDir exists, which
-    # causes "fatal error RC1109: error creating ver.res" and silently drops the
-    # wix.*.nupkg without aborting build_all.cmd.
-    mkdir -p "$SRC_DIR/wix/build/wix/obj/wixnative/Release/x86"
-    mkdir -p "$SRC_DIR/wix/build/wix/obj/wixnative/Release/x64"
-    mkdir -p "$SRC_DIR/wix/build/wix/obj/wixnative/Release/ARM64"
+    echo "  Extracting..."
+    unzip -q "$SRC_DIR/wix.zip" -d "$SRC_DIR/extract"
 
-    echo "  Building from source (Release, tests disabled)..."
-    cd "$SRC_DIR/wix"
-    export RuntimeTestsEnabled=false
-    # .NET SDK 8.0.400+ promotes targeting net6.0 from a warning to a build error
-    # (NETSDK1138). WiX v4.0.6's wix.csproj targets net6.0; disable the EOL check.
-    export CheckEolTargetFramework=false
-    # Use build_all.cmd directly to avoid the signing step in build_official.cmd.
-    # On windows-2022, build_all.cmd's vswhere -version [17.0,18.0) finds VS 2022
-    # and initializes the v143 developer environment automatically.
-    # set +e so cmd.exe exit codes aren't silently swallowed by Git Bash under set -e.
-    set +e
-    cmd //c "src\\build_all.cmd" Release
-    local BUILD_RC=$?
-    set -e
-    if [ $BUILD_RC -ne 0 ]; then
-        echo "❌ build_all.cmd failed with exit code $BUILD_RC"
-        exit $BUILD_RC
-    fi
+    # Strip dev-only payloads: sdk/ (libs + headers) and doc/ (chm/xsd).
+    # Everything else is kept, including LICENSE.TXT (MS-RL, required for
+    # redistribution), the candle/light/* tools, the Wix*Extension.dll set,
+    # the ICE cubes, and x86/burn.exe.
+    echo "  Filtering runtime files (excluding sdk/ and doc/)..."
+    rsync -a --exclude='sdk/' --exclude='doc/' "$SRC_DIR/extract/" "$SRC_DIR/bundle/"
 
-    echo "  Locating nupkg artifact..."
-    local NUPKG
-    # grep -v on empty input exits 1, which with pipefail kills the script before
-    # the diagnostic below runs.  Use find's own filter and || true instead.
-    NUPKG="$(find "$SRC_DIR/wix/build/artifacts" -name "wix.*.nupkg" \
-        ! -name "*.symbols.nupkg" 2>/dev/null | head -1 || true)"
-    if [ -z "$NUPKG" ]; then
-        echo "❌ wix.*.nupkg not found in build/artifacts/ — listing contents:"
-        find "$SRC_DIR/wix/build/artifacts" -type f 2>/dev/null | head -30 || true
+    if [ ! -f "$SRC_DIR/bundle/LICENSE.TXT" ]; then
+        echo "❌ LICENSE.TXT missing from bundle — required by MS-RL for redistribution"
         exit 1
     fi
-    echo "  Found: $(basename "$NUPKG")"
-
-    echo "  Extracting bundle contents from nupkg..."
-    local EXTRACT_DIR="$SRC_DIR/extract"
-    mkdir -p "$EXTRACT_DIR"
-    # nupkg is a zip; extract everything — unzip's * doesn't cross /, so a
-    # pattern like "tools/net6.0/any/*" silently drops runtimes/ and cubes/.
-    # The archive is built from CONTENT_DIR so NuGet metadata is never included.
-    unzip -q "$NUPKG" -d "$EXTRACT_DIR"
-
-    local CONTENT_DIR="$EXTRACT_DIR/tools/net6.0/any"
-    if [ ! -d "$CONTENT_DIR" ]; then
-        echo "❌ Expected tools/net6.0/any/ inside nupkg"
-        exit 1
-    fi
-
-    # Include the license (required by MS-RL for redistribution)
-    cp "$SRC_DIR/wix/LICENSE.TXT" "$CONTENT_DIR/"
 
     echo "  Creating archive..."
-    (cd "$CONTENT_DIR" && tar -czf "$OUT_DIR/$ARCHIVE_NAME" .)
+    (cd "$SRC_DIR/bundle" && tar -czf "$OUT_DIR/$ARCHIVE_NAME" .)
 
     echo ""
     echo "  Done: $OUT_DIR/$ARCHIVE_NAME ($(du -h "$OUT_DIR/$ARCHIVE_NAME" | cut -f1))"
@@ -154,7 +118,7 @@ test_mac() {
     echo ""
 
     if ! command -v wine &>/dev/null; then
-        echo "❌ wine not found. Install via: brew install wine-stable"
+        echo "❌ wine not found. Install via: brew install --cask wine-stable"
         exit 1
     fi
 
@@ -194,16 +158,16 @@ Options:
   --help, -h            Show this help
 
 Targets:
-  build       Compile WiX v${WIX_VERSION} from source and produce the tar.gz artifact
-              Requires Windows (windows-2025 GitHub Actions runner)
-  test-mac    Smoke test on macOS using native Wine (brew install wine-stable)
+  build       Download WiX v${WIX_VERSION} binaries and produce the tar.gz artifact
+              (needs curl, unzip, rsync, tar — runs on any host, no compiler)
+  test-mac    Smoke test on macOS using native Wine (brew install --cask wine-stable)
   test-linux  Build linux/amd64 Docker image and smoke test via Wine
   test-all    Run test-mac and test-linux
-  all         build + test-linux (default, matches CI)
+  all         build + tests (default)
 
 Examples:
-  ./build.sh                       # Full pipeline (Windows CI)
-  ./build.sh --target build        # Compile artifact only (Windows required)
+  ./build.sh                       # Full pipeline
+  ./build.sh --target build        # Produce the artifact only
   ./build.sh --target test-mac     # Test existing artifact on macOS
   ./build.sh --target test-linux   # Test existing artifact in Docker
   ./build.sh --target test-all     # Run both test targets

--- a/packages/wix/package.json
+++ b/packages/wix/package.json
@@ -1,5 +1,5 @@
 {
     "name": "wix",
     "version": "1.0.0",
-    "description": "WiX Toolset v4 built from source"
+    "description": "WiX Toolset v3 binaries (candle, light, extensions) for building MSI installers"
 }


### PR DESCRIPTION
Downgrading WiX Toolset to v3.14.1 (candle/light) instead of the v4 source-compiled toolset - enables restoring the cross-platform candle.exe + light.exe pipeline that runs under Wine/mono for MSI and Squirrel.Windows builds in electron-builder

v4 is not supported in electron-builder, but hey, we have it in our git history now in case we ever want to.