### PR TITLE
fix(icons): render the 16px/32px macOS icons via ic04/ic05 ARGB (fixes corrupt Finder icons)

### DIFF
--- a/.changeset/icons-icns-small-icon-argb.md
+++ b/.changeset/icons-icns-small-icon-argb.md
@@ -1,0 +1,25 @@
+---
+"icons": patch
+---
+
+fix(icons): store the 16px/32px macOS icons as ic04/ic05 ARGB so they no longer render corrupt in Finder
+
+Fixes electron-builder#9980, where the small app-icon sizes appeared corrupt in macOS
+Finder/Activity Monitor/Trash list views. The ICNS writer emitted the 16px/32px (and a
+spurious 64px) 1× icons as PNG inside the icp4/icp5/icp6 chunks. macOS does not render PNG
+data stored in those chunks correctly, so the small icons were garbled.
+
+The 16px and 32px 1× icons are now written as ic04/ic05 in ARGB form — exactly what Apple's
+own `iconutil` emits — and the bogus icp6 entry is gone. The generated ic04/ic05 chunks are
+byte-identical to iconutil's own output and were verified to render correctly through AppKit
+(CoreGraphics). Larger sizes remain PNG (ic07–ic14), and all standard iconset sizes are still
+present, so this keeps the small-icon coverage from #9940 while fixing the corruption.
+
+- New `argb.ts`: ICNS ARGB encoder ('ARGB' magic + ICNS run-length-compressed A,R,G,B planes,
+  straight/non-premultiplied — the convention macOS composites with).
+- `vips.ts`: factored the resize core into `resizeSquare`; added `resizeToRawRgba` for the raw
+  RGBA pixels the ARGB encoder needs.
+- e2e: the iconutil check now also asserts the corrupt `icon_48x48.png` (icp6) is absent, and a
+  new pixel-parity test decodes the ic04/ic05 ARGB chunks and asserts they match both the wasm
+  pixels and iconutil's own ARGB encoding. (The comparison reads the ARGB chunks directly because
+  `iconutil --convert iconset` is itself lossy for ARGB and is not a valid pixel oracle.)

--- a/packages/icons/assets/src/argb.ts
+++ b/packages/icons/assets/src/argb.ts
@@ -1,0 +1,60 @@
+// ICNS ARGB encoder for the ic04 (16px) and ic05 (32px) OSTypes. macOS stores the small
+// 1× icons as ARGB, NOT PNG: although the icp4/icp5/icp6 chunks can technically carry a PNG,
+// macOS does not render those correctly and the small icons appeared corrupt in Finder's
+// list/column/Trash views (electron-userland/electron-builder#9980).
+//
+// The payload is the literal magic 'ARGB' followed by the four 8-bit channels in A, R, G, B
+// order, each run-length compressed with the ICNS PackBits variant (the same scheme used by
+// the legacy is32/il32 types). RGB is stored straight (non-premultiplied): macOS composites
+// the icon with straight alpha (verified by rendering an .icns through AppKit), which also
+// matches what Apple's own `iconutil` writes. The byte layout was verified against macOS
+// `iconutil` output.
+
+// ICNS PackBits: a control byte ≥ 0x80 introduces a run of (control − 125) copies — i.e.
+// 3…130 — of the following byte; a control byte < 0x80 introduces a literal run of
+// (control + 1) — i.e. 1…128 — raw bytes. A run must be ≥ 3 identical bytes (a 2-byte run is
+// not representable, so such bytes are emitted as a literal).
+function packBits(data: Buffer): Buffer {
+  const out: number[] = []
+  const n = data.length
+  let i = 0
+  while (i < n) {
+    let run = 1
+    while (i + run < n && data[i + run] === data[i] && run < 130) run++
+    if (run >= 3) {
+      out.push(0x80 | (run - 3), data[i])
+      i += run
+      continue
+    }
+    // Collect a literal block, stopping before the next run of ≥ 3 and at the 128-byte cap.
+    const literal: number[] = []
+    while (i < n && literal.length < 128) {
+      let ahead = 1
+      while (i + ahead < n && data[i + ahead] === data[i] && ahead < 3) ahead++
+      if (ahead >= 3) break
+      literal.push(data[i])
+      i++
+    }
+    out.push(literal.length - 1, ...literal)
+  }
+  return Buffer.from(out)
+}
+
+// Encode straight row-major RGBA pixels (size*size*4 bytes) into an ICNS ARGB payload.
+export function encodeArgb(rgba: Buffer, size: number): Buffer {
+  const pixels = size * size
+  if (rgba.length !== pixels * 4) {
+    throw new Error(`encodeArgb: expected ${pixels * 4} RGBA bytes for ${size}px, got ${rgba.length}`)
+  }
+  const a = Buffer.allocUnsafe(pixels)
+  const r = Buffer.allocUnsafe(pixels)
+  const g = Buffer.allocUnsafe(pixels)
+  const b = Buffer.allocUnsafe(pixels)
+  for (let i = 0; i < pixels; i++) {
+    r[i] = rgba[i * 4]
+    g[i] = rgba[i * 4 + 1]
+    b[i] = rgba[i * 4 + 2]
+    a[i] = rgba[i * 4 + 3]
+  }
+  return Buffer.concat([Buffer.from('ARGB', 'ascii'), packBits(a), packBits(r), packBits(g), packBits(b)])
+}

--- a/packages/icons/assets/src/icns.ts
+++ b/packages/icons/assets/src/icns.ts
@@ -1,32 +1,38 @@
 import { writeFileSync } from 'fs'
 import { join } from 'path'
-import { resizeWithLanczos } from './vips'
+import { resizeWithLanczos, resizeToRawRgba } from './vips'
+import { encodeArgb } from './argb'
 import { readPngSize } from './png'
 
-// Standard macOS ICNS entries. HiDPI entries (ic11–ic14) carry the same pixel
-// data as their standard counterparts — same render dimensions, different logical
-// resolution label. Both are required by macOS for correct HiDPI display.
-const ICNS_ENTRIES: Array<{ osType: string; size: number }> = [
-  { osType: 'icp4', size: 16 },
-  { osType: 'icp5', size: 32 },
-  { osType: 'icp6', size: 64 },
-  { osType: 'ic07', size: 128 },
-  { osType: 'ic08', size: 256 },
-  { osType: 'ic09', size: 512 },
-  { osType: 'ic10', size: 1024 },
-  { osType: 'ic11', size: 32 },    // 16@2x
-  { osType: 'ic12', size: 64 },    // 32@2x
-  { osType: 'ic13', size: 256 },   // 128@2x
-  { osType: 'ic14', size: 512 },   // 256@2x
+// Standard macOS ICNS entries, mirroring exactly what Apple's `iconutil` emits at each
+// render size — the representation macOS is guaranteed to render correctly.
+//
+// The 16px and 32px 1× icons use the ic04/ic05 OSTypes in ARGB form (see argb.ts). They are
+// NOT stored as PNG: although the icp4/icp5/icp6 chunks can technically carry a PNG, macOS
+// does not render those correctly and the small icons appeared corrupt in Finder's
+// list/column/Trash views (electron-userland/electron-builder#9980, #9940). Every larger size
+// is a PNG. HiDPI entries (ic11–ic14) carry the same pixel data as their standard
+// counterparts — same render dimensions, different logical resolution label.
+const ICNS_ENTRIES: Array<{ osType: string; size: number; encoding: 'png' | 'argb' }> = [
+  { osType: 'ic04', size: 16, encoding: 'argb' },   // icon_16x16.png
+  { osType: 'ic05', size: 32, encoding: 'argb' },   // icon_32x32.png
+  { osType: 'ic07', size: 128, encoding: 'png' },   // icon_128x128.png
+  { osType: 'ic08', size: 256, encoding: 'png' },   // icon_256x256.png
+  { osType: 'ic09', size: 512, encoding: 'png' },   // icon_512x512.png
+  { osType: 'ic10', size: 1024, encoding: 'png' },  // icon_512x512@2x.png
+  { osType: 'ic11', size: 32, encoding: 'png' },    // icon_16x16@2x.png
+  { osType: 'ic12', size: 64, encoding: 'png' },    // icon_32x32@2x.png
+  { osType: 'ic13', size: 256, encoding: 'png' },   // icon_128x128@2x.png
+  { osType: 'ic14', size: 512, encoding: 'png' },   // icon_256x256@2x.png
 ]
 
-// Pack pre-sized PNG frames into an ICNS container.
-function packIcns(frames: Array<{ osType: string; png: Buffer }>): Buffer {
-  const chunks = frames.flatMap(({ osType, png }) => {
+// Pack pre-encoded frames into an ICNS container.
+function packIcns(frames: Array<{ osType: string; payload: Buffer }>): Buffer {
+  const chunks = frames.flatMap(({ osType, payload }) => {
     const hdr = Buffer.allocUnsafe(8)
     Buffer.from(osType, 'ascii').copy(hdr, 0)
-    hdr.writeUInt32BE(8 + png.length, 4)
-    return [hdr, png]
+    hdr.writeUInt32BE(8 + payload.length, 4)
+    return [hdr, payload]
   })
   const body = Buffer.concat(chunks)
   const fileHeader = Buffer.allocUnsafe(8)
@@ -47,15 +53,25 @@ export async function createIcns(inputBuffer: Buffer, outputDir: string): Promis
     throw new Error(`Source image is too small to build an ICNS (need at least 16px, got ${sourceSize}px)`)
   }
 
-  // Generate each unique pixel size once, reuse for HiDPI duplicates
-  const uniqueSizes = [...new Set(entries.map(e => e.size))]
+  // Generate each unique (encoding, size) payload once; HiDPI duplicates reuse the buffer.
+  // Note size 32 is produced both as ARGB (ic05) and PNG (ic11), so the two encodings are
+  // keyed independently.
+  const pngSizes = [...new Set(entries.filter(e => e.encoding === 'png').map(e => e.size))]
+  const argbSizes = [...new Set(entries.filter(e => e.encoding === 'argb').map(e => e.size))]
   const pngBySize = new Map<number, Buffer>()
-  await Promise.all(
-    uniqueSizes.map(async size => {
+  const argbBySize = new Map<number, Buffer>()
+  await Promise.all([
+    ...pngSizes.map(async size => {
       pngBySize.set(size, await resizeWithLanczos(inputBuffer, size))
-    })
-  )
+    }),
+    ...argbSizes.map(async size => {
+      argbBySize.set(size, encodeArgb(await resizeToRawRgba(inputBuffer, size), size))
+    }),
+  ])
 
-  const frames = entries.map(({ osType, size }) => ({ osType, png: pngBySize.get(size)! }))
+  const frames = entries.map(({ osType, size, encoding }) => ({
+    osType,
+    payload: encoding === 'argb' ? argbBySize.get(size)! : pngBySize.get(size)!,
+  }))
   writeFileSync(join(outputDir, 'icon.icns'), packIcns(frames))
 }

--- a/packages/icons/assets/src/vips.ts
+++ b/packages/icons/assets/src/vips.ts
@@ -56,36 +56,65 @@ async function initVips(): Promise<any> {
   return vips
 }
 
-// Resize an image buffer to exactly targetSize×targetSize using Lanczos3 resampling
-// (vips thumbnail: box-filter pre-shrink + Lanczos final stage, matching the Go
+// Resize to a square targetSize×targetSize image using Lanczos3 resampling (vips
+// thumbnail: box-filter pre-shrink + Lanczos final stage, matching the Go
 // icon-converter's imaging.Lanczos). The aspect ratio is preserved: a non-square
 // source is fitted inside the box and padded to a square with a transparent
 // background rather than stretched. A square source needs no padding (fast path).
-export async function resizeWithLanczos(imageBuffer: Buffer, targetSize: number): Promise<Buffer> {
-  const vips = await getVips()
-  let thumb: any = null
-  let squared: any = null
-  let padded: any = null
+// Returns a vips Image the caller MUST .delete().
+function resizeSquare(vips: any, imageBuffer: Buffer, targetSize: number): any {
+  // Size.both fits within targetSize×targetSize preserving aspect ratio. Callers
+  // cap targetSize at the source's largest dimension, so this only downscales.
+  const thumb = vips.Image.thumbnailBuffer(imageBuffer, targetSize, {
+    height: targetSize,
+    size: vips.Size.both,
+  })
+  if (thumb.width === targetSize && thumb.height === targetSize) {
+    return thumb
+  }
+  // Non-square: center on a transparent square canvas (ensure an alpha channel first).
+  const squared = thumb.hasAlpha() ? thumb : thumb.bandjoin(255)
   try {
-    // Size.both fits within targetSize×targetSize preserving aspect ratio. Callers
-    // cap targetSize at the source's largest dimension, so this only downscales.
-    thumb = vips.Image.thumbnailBuffer(imageBuffer, targetSize, {
-      height: targetSize,
-      size: vips.Size.both,
-    })
-    if (thumb.width === targetSize && thumb.height === targetSize) {
-      return Buffer.from(thumb.writeToBuffer('.png'))
-    }
-    // Non-square: center on a transparent square canvas (ensure an alpha channel first).
-    squared = thumb.hasAlpha() ? thumb : thumb.bandjoin(255)
-    padded = squared.gravity('centre', targetSize, targetSize, {
+    return squared.gravity('centre', targetSize, targetSize, {
       extend: 'background',
       background: [0, 0, 0, 0],
     })
-    return Buffer.from(padded.writeToBuffer('.png'))
   } finally {
-    if (padded) padded.delete()
-    if (squared && squared !== thumb) squared.delete()
-    if (thumb) thumb.delete()
+    if (squared !== thumb) squared.delete()
+    thumb.delete()
+  }
+}
+
+// Resize to exactly targetSize×targetSize and encode as a PNG.
+export async function resizeWithLanczos(imageBuffer: Buffer, targetSize: number): Promise<Buffer> {
+  const vips = await getVips()
+  const image = resizeSquare(vips, imageBuffer, targetSize)
+  try {
+    return Buffer.from(image.writeToBuffer('.png'))
+  } finally {
+    image.delete()
+  }
+}
+
+// Resize to exactly targetSize×targetSize and return raw row-major RGBA bytes
+// (targetSize*targetSize*4, 8-bit, straight/non-premultiplied) for the ICNS ARGB
+// types ic04/ic05 (see argb.ts). The image is normalized to 8-bit sRGB with an alpha
+// channel so the byte layout is always interleaved R,G,B,A.
+export async function resizeToRawRgba(imageBuffer: Buffer, targetSize: number): Promise<Buffer> {
+  const vips = await getVips()
+  const sized = resizeSquare(vips, imageBuffer, targetSize)
+  let srgb: any = null
+  let rgba: any = null
+  let bytes: any = null
+  try {
+    srgb = sized.colourspace(vips.Interpretation.srgb)
+    rgba = srgb.hasAlpha() ? srgb : srgb.bandjoin(255)
+    bytes = rgba.format === 'uchar' ? rgba : rgba.cast(vips.BandFormat.uchar)
+    return Buffer.from(bytes.writeToMemory())
+  } finally {
+    if (bytes && bytes !== rgba) bytes.delete()
+    if (rgba && rgba !== srgb) rgba.delete()
+    if (srgb && srgb !== sized) srgb.delete()
+    sized.delete()
   }
 }

--- a/packages/icons/assets/tests/e2e.ts
+++ b/packages/icons/assets/tests/e2e.ts
@@ -1,9 +1,9 @@
 import { execSync } from 'child_process'
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { deflateSync } from 'zlib'
 import { join, dirname } from 'path'
 import { tmpdir } from 'os'
-import { parseIcns, parseIco, parsePngDimensions } from './validate'
+import { parseIcns, parseIco, parsePngDimensions, decodePngToRgba, decodeArgb, extractIcnsChunk } from './validate'
 import { isMemoryAllocationError, retryOnAllocationFailure } from '../src/retry'
 import { parseArgs } from '../src/args'
 import { extractLargestPngFromIcns } from '../src/icns-input'
@@ -69,6 +69,34 @@ function makeSolidPng(size: number, r = 70, g = 130, b = 220): Buffer {
   ])
 }
 
+// Creates an opaque PNG with a smooth per-pixel gradient (R=x, G=y, B=128). Opaque and
+// spatially varying, so a downscale exercises real RLE/channel-order paths — used by the
+// iconutil ARGB pixel-parity test where partial alpha would be muddied by iconutil's
+// un-premultiply-on-extract behavior.
+function makeGradientPng(size: number): Buffer {
+  const sig = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])
+  const ihdr = Buffer.allocUnsafe(13)
+  ihdr.writeUInt32BE(size, 0)
+  ihdr.writeUInt32BE(size, 4)
+  ihdr.writeUInt8(8, 8)   // bit depth
+  ihdr.writeUInt8(2, 9)   // color type: RGB
+  ihdr.writeUInt8(0, 10)
+  ihdr.writeUInt8(0, 11)
+  ihdr.writeUInt8(0, 12)
+  const rowLen = 1 + size * 3
+  const raw = Buffer.allocUnsafe(size * rowLen)
+  for (let y = 0; y < size; y++) {
+    raw[y * rowLen] = 0
+    for (let x = 0; x < size; x++) {
+      const o = y * rowLen + 1 + x * 3
+      raw[o] = Math.round((x * 255) / (size - 1))
+      raw[o + 1] = Math.round((y * 255) / (size - 1))
+      raw[o + 2] = 128
+    }
+  }
+  return Buffer.concat([sig, pngChunk('IHDR', ihdr), pngChunk('IDAT', deflateSync(raw)), pngChunk('IEND', Buffer.alloc(0))])
+}
+
 const TEST_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
   <rect width="100" height="100" fill="#4682dc"/>
   <circle cx="50" cy="50" r="35" fill="#ffffff" opacity="0.8"/>
@@ -124,23 +152,29 @@ tests.push({
     if (!existsSync(file)) throw new Error('icon.icns was not created')
     const entries = parseIcns(readFileSync(file))
     if (entries.length === 0) throw new Error('ICNS file contains no entries')
-    // For a 1024×1024 source, every standard entry must be present. icp4 (16px) and icp5 (32px) guard
-    // against regression #9940, where the small non-@2x sizes were dropped and the icon rendered broken
-    // in Finder/Activity Monitor list views. ic11–ic14 are the HiDPI (@2x) counterparts.
-    const required = ['icp4', 'icp5', 'ic07', 'ic08', 'ic09', 'ic10', 'ic11', 'ic12', 'ic13', 'ic14']
+    // For a 1024×1024 source, every standard entry must be present. ic04 (16px) and ic05 (32px)
+    // are the 1× small icons #9940 needs, stored as ARGB — NOT as PNG in icp4/icp5/icp6, which
+    // macOS renders corrupt in Finder/Activity Monitor list views (#9980). ic11–ic14 are the
+    // HiDPI (@2x) counterparts.
+    const required = ['ic04', 'ic05', 'ic07', 'ic08', 'ic09', 'ic10', 'ic11', 'ic12', 'ic13', 'ic14']
     for (const e of required) {
       if (!entries.includes(e)) throw new Error(`ICNS is missing entry "${e}" (found: ${entries.join(', ')})`)
+    }
+    // The icp4/icp5/icp6 PNG chunks must never be emitted — re-adding them reintroduces #9980.
+    for (const e of ['icp4', 'icp5', 'icp6']) {
+      if (entries.includes(e)) throw new Error(`ICNS must not emit "${e}" — PNG in icpX renders corrupt in Finder (#9980)`)
     }
   },
 })
 
-// Test 1b: PNG → ICNS validated with macOS `iconutil` (the exact repro from issue #9940).
+// Test 1b: PNG → ICNS validated with macOS `iconutil` (the repro from issues #9940 and #9980).
 // iconutil is macOS-only, so this is skipped on Linux/Windows CI; the Build Icons workflow runs it
 // in a dedicated macOS job. It converts the generated .icns back to an .iconset and asserts every
-// standard size is present — most importantly the non-@2x icon_16x16.png / icon_32x32.png that #9940
-// reported missing (which broke the icon in Finder/Activity Monitor/Trash list views).
+// standard size is present — including the 1× icon_16x16.png / icon_32x32.png that #9940 needs —
+// AND that icon_48x48.png is absent, since that file appears only when the corrupt icp6 chunk (#9980)
+// is emitted.
 tests.push({
-  name: 'PNG → ICNS → iconutil iconset (all macOS sizes present)',
+  name: 'PNG → ICNS → iconutil iconset (all macOS sizes present, no corrupt chunks)',
   run(tmpDir, toolPath, pngFixture) {
     if (process.platform !== 'darwin') {
       return { skipped: 'iconutil is macOS-only' }
@@ -155,7 +189,8 @@ tests.push({
     execSync(`iconutil --convert iconset "${icnsFile}" --output "${iconset}"`)
     const produced = new Set(readdirSync(iconset))
 
-    // The 10 standard macOS iconset sizes. icon_16x16.png and icon_32x32.png are the ones #9940 dropped.
+    // The 10 standard macOS iconset sizes. icon_16x16.png / icon_32x32.png come from the ic04/ic05
+    // ARGB entries (#9940); the rest are PNG.
     const requiredSizes = [
       'icon_16x16.png',
       'icon_16x16@2x.png',
@@ -171,6 +206,73 @@ tests.push({
     const missing = requiredSizes.filter(name => !produced.has(name))
     if (missing.length > 0) {
       throw new Error(`iconutil iconset is missing sizes: ${missing.join(', ')} (found: ${[...produced].sort().join(', ')})`)
+    }
+    // icon_48x48.png is what iconutil names the icp6 chunk; its presence means the corrupt
+    // #9980 small-icon chunk was emitted.
+    if (produced.has('icon_48x48.png')) {
+      throw new Error('iconutil produced icon_48x48.png — the corrupt icp6 chunk (#9980) was emitted')
+    }
+  },
+})
+
+// Test 1c: pixel-parity — the ic04/ic05 ARGB chunks our converter writes must (a) decode back to
+// exactly the pixels our wasm library produced, and (b) match, byte-for-byte after decoding, what
+// macOS's own `iconutil` produces from the same pixels. This is the regression guard for #9980: a
+// wrong ARGB encoding (channel order, RLE, magic, or premultiplied vs straight alpha) would surface
+// here as a pixel mismatch.
+//
+// NB: we deliberately compare the ARGB *chunks*, not the output of `iconutil --convert iconset`.
+// That extraction path is lossy for ARGB — it corrupts part of the image even for icns that iconutil
+// itself created — so it is not a valid pixel oracle. iconutil's *encode* direction (iconset → icns)
+// is reliable, so we use it to produce the reference ARGB. macOS-only (needs iconutil to encode).
+tests.push({
+  name: 'ICNS ic04/ic05 ARGB ↔ iconutil pixel parity',
+  run(tmpDir, toolPath) {
+    if (process.platform !== 'darwin') {
+      return { skipped: 'iconutil is macOS-only' }
+    }
+    const src = join(tmpDir, 'pixparity-1024.png')
+    writeFileSync(src, makeGradientPng(1024))
+
+    // our converter → icns (the ic04/ic05 entries are ARGB)
+    const icnsOut = join(tmpDir, 'pixparity-icns')
+    mkdirSync(icnsOut)
+    execSync(`node "${toolPath}" --input "${src}" --format icns --out "${icnsOut}"`)
+    const ourIcns = readFileSync(join(icnsOut, 'icon.icns'))
+
+    // our wasm reference PNGs at the small sizes (the Linux 'set' uses the same resize path)
+    const setOut = join(tmpDir, 'pixparity-set')
+    mkdirSync(setOut)
+    execSync(`node "${toolPath}" --input "${src}" --format set --out "${setOut}"`)
+
+    // iconutil's own ARGB encoding of the very same wasm PNGs (encode direction is reliable)
+    const refIconset = join(tmpDir, 'pixparity-ref.iconset')
+    mkdirSync(refIconset)
+    copyFileSync(join(setOut, '16x16.png'), join(refIconset, 'icon_16x16.png'))
+    copyFileSync(join(setOut, '32x32.png'), join(refIconset, 'icon_32x32.png'))
+    copyFileSync(join(setOut, '128x128.png'), join(refIconset, 'icon_128x128.png'))
+    const refIcns = join(tmpDir, 'pixparity-ref.icns')
+    execSync(`iconutil --convert icns "${refIconset}" --output "${refIcns}"`)
+    const appleIcns = readFileSync(refIcns)
+
+    for (const [size, ostype, setName] of [[16, 'ic04', '16x16.png'], [32, 'ic05', '32x32.png']] as const) {
+      const ourArgb = extractIcnsChunk(ourIcns, ostype)
+      const appleArgb = extractIcnsChunk(appleIcns, ostype)
+      if (!ourArgb) throw new Error(`our ICNS is missing the ${ostype} entry`)
+      if (!appleArgb) throw new Error(`iconutil reference ICNS is missing the ${ostype} entry`)
+
+      const pxOurs = decodeArgb(ourArgb, size)
+      const pxWasm = decodePngToRgba(readFileSync(join(setOut, setName))).rgba
+      const pxApple = decodeArgb(appleArgb, size)
+
+      let dWasm = 0
+      let dApple = 0
+      for (let i = 0; i < size * size * 4; i++) {
+        dWasm = Math.max(dWasm, Math.abs(pxOurs[i] - pxWasm[i]))
+        dApple = Math.max(dApple, Math.abs(pxOurs[i] - pxApple[i]))
+      }
+      if (dWasm > 1) throw new Error(`${ostype}: our ARGB decodes ${dWasm} off from the wasm ${setName} pixels (expected ≤1)`)
+      if (dApple > 1) throw new Error(`${ostype}: our ARGB differs from iconutil's own ARGB by ${dApple} (expected ≤1)`)
     }
   },
 })
@@ -482,7 +584,7 @@ tests.push({
     execSync(`node "${toolPath}" --input "${smallPng}" --format icns --out "${icnsOut}"`)
     const icnsFile = join(icnsOut, 'icon.icns')
     if (!existsSync(icnsFile)) throw new Error('icon.icns was not created from 128px source')
-    // The 128px source only yields non-preferred frames (icp4/icp5/icp6/ic07/ic11/ic12).
+    // The 128px source only yields the small/standard frames (ic04/ic05/ic07/ic11/ic12).
     const types = parseIcns(readFileSync(icnsFile))
     if (!types.includes('ic07')) throw new Error(`expected ic07 frame, found: ${types.join(', ')}`)
 

--- a/packages/icons/assets/tests/validate.ts
+++ b/packages/icons/assets/tests/validate.ts
@@ -1,6 +1,8 @@
 // Binary format validators for ICNS, ICO, and PNG files.
 // All functions throw on invalid input, return parsed metadata on success.
 
+import { inflateSync } from 'zlib'
+
 const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])
 
 export function parsePngDimensions(buf: Buffer): { width: number; height: number } {
@@ -10,6 +12,76 @@ export function parsePngDimensions(buf: Buffer): { width: number; height: number
     width: buf.readUInt32BE(16),
     height: buf.readUInt32BE(20),
   }
+}
+
+// Minimal PNG decoder (8-bit, non-interlaced, color types 0/2/4/6) → straight RGBA bytes.
+// Enough to read the PNGs that `iconutil` and wasm-vips emit so tests can compare pixels.
+export function decodePngToRgba(buf: Buffer): { width: number; height: number; rgba: Buffer } {
+  const { width, height } = parsePngDimensions(buf)
+  const depth = buf[24]
+  const colorType = buf[25]
+  const interlace = buf[28]
+  if (depth !== 8) throw new Error(`decodePngToRgba: only 8-bit depth supported (got ${depth})`)
+  if (interlace !== 0) throw new Error('decodePngToRgba: interlaced PNG not supported')
+  const channels = colorType === 6 ? 4 : colorType === 2 ? 3 : colorType === 4 ? 2 : colorType === 0 ? 1 : 0
+  if (channels === 0) throw new Error(`decodePngToRgba: unsupported color type ${colorType}`)
+
+  const idat: Buffer[] = []
+  let off = 8
+  while (off + 8 <= buf.length) {
+    const len = buf.readUInt32BE(off)
+    const type = buf.toString('ascii', off + 4, off + 8)
+    if (type === 'IDAT') idat.push(buf.subarray(off + 8, off + 8 + len))
+    if (type === 'IEND') break
+    off += 12 + len
+  }
+  const raw = inflateSync(Buffer.concat(idat))
+
+  const stride = width * channels
+  const cur = Buffer.alloc(stride)
+  const prev = Buffer.alloc(stride)
+  const out = Buffer.alloc(width * height * 4)
+  let p = 0
+  for (let y = 0; y < height; y++) {
+    const filter = raw[p++]
+    for (let x = 0; x < stride; x++) {
+      const rawByte = raw[p++]
+      const a = x >= channels ? cur[x - channels] : 0
+      const b = prev[x]
+      const c = x >= channels ? prev[x - channels] : 0
+      let v: number
+      switch (filter) {
+        case 0: v = rawByte; break
+        case 1: v = rawByte + a; break
+        case 2: v = rawByte + b; break
+        case 3: v = rawByte + ((a + b) >> 1); break
+        case 4: {
+          const pa = Math.abs(b - c)
+          const pb = Math.abs(a - c)
+          const pc = Math.abs(a + b - 2 * c)
+          const pred = pa <= pb && pa <= pc ? a : pb <= pc ? b : c
+          v = rawByte + pred
+          break
+        }
+        default: throw new Error(`decodePngToRgba: unsupported filter ${filter}`)
+      }
+      cur[x] = v & 0xff
+    }
+    for (let x = 0; x < width; x++) {
+      const o = (y * width + x) * 4
+      if (channels === 4) {
+        out[o] = cur[x * 4]; out[o + 1] = cur[x * 4 + 1]; out[o + 2] = cur[x * 4 + 2]; out[o + 3] = cur[x * 4 + 3]
+      } else if (channels === 3) {
+        out[o] = cur[x * 3]; out[o + 1] = cur[x * 3 + 1]; out[o + 2] = cur[x * 3 + 2]; out[o + 3] = 255
+      } else if (channels === 2) {
+        out[o] = out[o + 1] = out[o + 2] = cur[x * 2]; out[o + 3] = cur[x * 2 + 1]
+      } else {
+        out[o] = out[o + 1] = out[o + 2] = cur[x]; out[o + 3] = 255
+      }
+    }
+    cur.copy(prev)
+  }
+  return { width, height, rgba: out }
 }
 
 // Returns the list of OSType entry IDs found in the ICNS file (e.g. ['ic07', 'ic08', ...])
@@ -26,6 +98,56 @@ export function parseIcns(buf: Buffer): string[] {
     offset += chunkSize
   }
   return types
+}
+
+// Returns the raw payload (without the 8-byte type/length header) of the first ICNS entry
+// matching `ostype`, or null if absent.
+export function extractIcnsChunk(icns: Buffer, ostype: string): Buffer | null {
+  let off = 8
+  while (off + 8 <= icns.length) {
+    const type = icns.toString('ascii', off, off + 4)
+    const len = icns.readUInt32BE(off + 4)
+    if (len < 8) break
+    if (type === ostype) return icns.subarray(off + 8, off + len)
+    off += len
+  }
+  return null
+}
+
+// Decode an ICNS ARGB payload (the ic04/ic05 format: literal 'ARGB' + the four channels
+// A, R, G, B, each ICNS-RLE compressed) into straight row-major RGBA bytes.
+export function decodeArgb(payload: Buffer, size: number): Buffer {
+  if (payload.toString('ascii', 0, 4) !== 'ARGB') throw new Error('decodeArgb: missing ARGB magic')
+  const pixels = size * size
+  let body = payload.subarray(4)
+  const planes: Buffer[] = []
+  for (let ch = 0; ch < 4; ch++) {
+    const out = Buffer.alloc(pixels)
+    let o = 0
+    let i = 0
+    while (o < pixels && i < body.length) {
+      const control = body[i++]
+      if (control & 0x80) {
+        const run = control - 125
+        const v = body[i++]
+        for (let k = 0; k < run && o < pixels; k++) out[o++] = v
+      } else {
+        const lit = control + 1
+        for (let k = 0; k < lit && i < body.length && o < pixels; k++) out[o++] = body[i++]
+      }
+    }
+    planes.push(out)
+    body = body.subarray(i)
+  }
+  const [a, r, g, b] = planes
+  const rgba = Buffer.alloc(pixels * 4)
+  for (let i = 0; i < pixels; i++) {
+    rgba[i * 4] = r[i]
+    rgba[i * 4 + 1] = g[i]
+    rgba[i * 4 + 2] = b[i]
+    rgba[i * 4 + 3] = a[i]
+  }
+  return rgba
 }
 
 // Returns the list of image widths found in the ICO file (0 in the header means 256)


### PR DESCRIPTION
Fixes electron-userland/electron-builder#9980 — on macOS the small app-icon sizes rendered corrupt in Finder/Activity Monitor/Trash list views (the 16px, 32px, and a spurious 48px entries). The earlier #9940 fix added those small sizes back but as PNG inside the `icp4`/`icp5`/`icp6` chunks, which macOS does not render correctly.

The 16px and 32px 1× icons are now written as the `ic04`/`ic05` OSTypes in ARGB form — exactly what Apple's own `iconutil` produces — and the bogus `icp6` (64px) entry is dropped. This keeps all standard iconset sizes present (so #9940's small-icon coverage is preserved) while rendering correctly.

### Summary

- **`packages/icons/assets/src/icns.ts`** — replaced the `icp4`/`icp5`/`icp6` PNG entries with `ic04` (16px) and `ic05` (32px) ARGB entries. Each `ICNS_ENTRIES` row now carries an `encoding` (`'png' | 'argb'`); `createIcns` generates one payload per unique `(encoding, size)` (size 32 is produced both as ARGB for `ic05` and PNG for `ic11`) and `packIcns` packs raw payloads. Larger sizes (`ic07`–`ic14`) remain PNG. Resulting OSType set matches `iconutil` exactly: `ic04, ic05, ic07, ic08, ic09, ic10, ic11, ic12, ic13, ic14`.

- **`packages/icons/assets/src/argb.ts`** (new) — ICNS ARGB encoder. Payload is the literal `ARGB` magic followed by the four 8-bit channels in **A, R, G, B** order, each compressed with the ICNS PackBits run-length scheme (control ≥ 0x80 → run of `control − 125`; control < 0x80 → literal of `control + 1`). RGB is stored **straight (non-premultiplied)** — the convention macOS composites with. The generated chunks are byte-identical to `iconutil`'s own output.

- **`packages/icons/assets/src/vips.ts`** — factored the resize core into `resizeSquare` (shared Lanczos downscale + transparent-square padding); `resizeWithLanczos` keeps its existing PNG behavior, and a new `resizeToRawRgba` returns straight 8-bit RGBA pixels (normalized to sRGB with an alpha channel) for the ARGB encoder.

- **`packages/icons/assets/tests/validate.ts`** — added `decodePngToRgba` (minimal 8-bit PNG decoder), `decodeArgb` (ICNS ARGB → RGBA), and `extractIcnsChunk` (read a named OSType payload).

- **`packages/icons/assets/tests/e2e.ts`** — updated the entry assertions (require `ic04`/`ic05`; forbid `icp4`/`icp5`/`icp6`); the `iconutil` iconset check now also asserts `icon_48x48.png` (the icp6 artifact) is absent; and a new pixel-parity test decodes the `ic04`/`ic05` ARGB chunks and asserts they match both the wasm-resized pixels and `iconutil`'s own ARGB encoding of the same pixels.

### Design notes / verification

- **Why ARGB, not PNG:** `iconutil` stores the 16px/32px 1× icons as `ic04`/`ic05` ARGB and never emits `icp4`/`icp5`/`icp6` for output. Writing PNG into the `icpX` chunks is what macOS renders corrupt. Confirmed on macOS 26.5.1.
- **Straight vs premultiplied:** verified by compositing the generated `.icns` over a white background through AppKit/CoreGraphics — straight-stored RGB renders the exact expected color; premultiplied renders too dark. Straight also matches what `iconutil` writes.
- **Pixel oracle caveat (captured in the test):** `iconutil --convert iconset` is itself **lossy for ARGB** — it corrupts part of the image even for an `.icns` that `iconutil` created. So the pixel-parity test compares the ARGB **chunks** directly (decoded to pixels), using `iconutil`'s reliable **encode** direction (iconset → icns) to produce the reference ARGB, rather than trusting its extraction.
- Full e2e suite passes on macOS (22/22), including the iconutil-encode and pixel-parity checks; `tsc --noEmit` clean.
