### PR TITLE
fix(7zip): bundle the 64-bit console builds for win-x64 and win-arm64

### DIFF
--- a/.changeset/seven-zip-win-64bit-7za.md
+++ b/.changeset/seven-zip-win-64bit-7za.md
@@ -1,0 +1,7 @@
+---
+"7zip": patch
+---
+
+fix(7zip): bundle the correct architecture-specific `7za.exe` for win-x64 and win-arm64
+
+The `7zip-win-x64` and `7zip-win-arm64` bundles previously shipped the 32-bit x86 `7za.exe` from the root of the upstream `7z-extra` archive, capping 7-Zip's compression memory budget and quietly collapsing LZMA2 multithreading. The 64-bit and ARM64 console builds from the archive's `x64/` and `arm64/` subdirectories are now bundled instead; the root x86 binary remains the fallback only for `7zip-win-ia32`, where it is correct. Fixes [#222](https://github.com/electron-userland/electron-builder-binaries/issues/222).

--- a/packages/7zip/assets/build.js
+++ b/packages/7zip/assets/build.js
@@ -293,24 +293,35 @@ function buildWin() {
   // Native ARM64 console build from the same extra package.
   const winArm64ExtraExe = join(winX64Extract, "arm64", "7za.exe");
 
-  // arm64: NSIS installer; fall back to x64 binary if 7za.exe not bundled
-  const arm64Installer = join(workDir, "win-arm64-installer.exe");
-  download(`${base}/7z${ver}-arm64.exe`, arm64Installer);
-  trackDownload("WARM64_SHA256", arm64Installer);
-  verifySha256(arm64Installer, WARM64_SHA256);
-  const arm64Exe = extractNsis(arm64Installer, join(workDir, "extract-win-arm64"));
-  if (arm64Exe) console.log(`  Found 7za.exe (arm64): ${arm64Exe}`);
-  else console.log("  ⚠️  7za.exe not found in arm64 installer — falling back to x64");
-  bundleWin("7zip-win-arm64", existsSync(winArm64ExtraExe) ? winArm64ExtraExe : (arm64Exe ?? winX64Exe));
+  // arm64: prefer the extra-package console build; otherwise extract the NSIS
+  // installer, falling back to the x64 binary if 7za.exe is not bundled there
+  let winArm64Exe = winArm64ExtraExe;
+  if (existsSync(winArm64ExtraExe)) {
+    console.log(`  Found 7za.exe (arm64): ${winArm64ExtraExe}`);
+  } else {
+    const arm64Installer = join(workDir, "win-arm64-installer.exe");
+    download(`${base}/7z${ver}-arm64.exe`, arm64Installer);
+    trackDownload("WARM64_SHA256", arm64Installer);
+    verifySha256(arm64Installer, WARM64_SHA256);
+    const arm64Exe = extractNsis(arm64Installer, join(workDir, "extract-win-arm64"));
+    if (arm64Exe) console.log(`  Found 7za.exe (arm64): ${arm64Exe}`);
+    else console.log("  ⚠️  7za.exe not found in arm64 installer — falling back to x64");
+    winArm64Exe = arm64Exe ?? winX64Exe;
+  }
+  bundleWin("7zip-win-arm64", winArm64Exe);
 
-  // ia32: NSIS installer; fall back to x64 binary if 7za.exe not bundled
+  // ia32: NSIS installer; fall back to the extra-package x86 build if 7za.exe not bundled
   const ia32Installer = join(workDir, "win-ia32-installer.exe");
   download(`${base}/7z${ver}.exe`, ia32Installer);
   trackDownload("WIA32_SHA256", ia32Installer);
   verifySha256(ia32Installer, WIA32_SHA256);
   const ia32Exe = extractNsis(ia32Installer, join(workDir, "extract-win-ia32"));
   if (ia32Exe) console.log(`  Found 7za.exe (ia32): ${ia32Exe}`);
-  else console.log("  ⚠️  7za.exe not found in ia32 installer — falling back to x64");
+  else console.log("  ⚠️  7za.exe not found in ia32 installer — falling back to the extra-package x86 build");
+  if (!ia32Exe && !existsSync(winIa32ExtraExe)) {
+    console.error("❌ 7za.exe not found in extra.7z root (ia32 fallback)");
+    process.exit(1);
+  }
   bundleWin("7zip-win-ia32", ia32Exe ?? winIa32ExtraExe);
 }
 

--- a/packages/7zip/assets/build.js
+++ b/packages/7zip/assets/build.js
@@ -276,12 +276,22 @@ function buildWin() {
   verifySha256(extraArchive, WX64_SHA256);
   mkdirSync(winX64Extract, { recursive: true });
   quiet(`7zz x -bd ${q(extraArchive)} -o${q(winX64Extract)} -y`);
-  const winX64Exe = join(winX64Extract, "7za.exe");
+  // The "extra" package roots the 32-bit x86 console build; the 64-bit and
+  // ARM64 console builds live in its x64/ and arm64/ subdirectories. Bundling
+  // the root binary shipped a 32-bit 7za as 7zip-win-x64, which caps 7-Zip's
+  // compression memory budget at 80% of 1.75 GiB and quietly collapses LZMA2
+  // multithreading to ~1 encoder (see electron-builder-binaries#222).
+  const winX64Exe = join(winX64Extract, "x64", "7za.exe");
   if (!existsSync(winX64Exe)) {
-    console.error("❌ 7za.exe not found in extra.7z");
+    console.error("❌ x64/7za.exe not found in extra.7z");
     process.exit(1);
   }
   bundleWin("7zip-win-x64", winX64Exe);
+  // The root of the extra package IS the 32-bit x86 build — the right
+  // fallback for ia32 (and never for x64/arm64).
+  const winIa32ExtraExe = join(winX64Extract, "7za.exe");
+  // Native ARM64 console build from the same extra package.
+  const winArm64ExtraExe = join(winX64Extract, "arm64", "7za.exe");
 
   // arm64: NSIS installer; fall back to x64 binary if 7za.exe not bundled
   const arm64Installer = join(workDir, "win-arm64-installer.exe");
@@ -291,7 +301,7 @@ function buildWin() {
   const arm64Exe = extractNsis(arm64Installer, join(workDir, "extract-win-arm64"));
   if (arm64Exe) console.log(`  Found 7za.exe (arm64): ${arm64Exe}`);
   else console.log("  ⚠️  7za.exe not found in arm64 installer — falling back to x64");
-  bundleWin("7zip-win-arm64", arm64Exe ?? winX64Exe);
+  bundleWin("7zip-win-arm64", existsSync(winArm64ExtraExe) ? winArm64ExtraExe : (arm64Exe ?? winX64Exe));
 
   // ia32: NSIS installer; fall back to x64 binary if 7za.exe not bundled
   const ia32Installer = join(workDir, "win-ia32-installer.exe");
@@ -301,7 +311,7 @@ function buildWin() {
   const ia32Exe = extractNsis(ia32Installer, join(workDir, "extract-win-ia32"));
   if (ia32Exe) console.log(`  Found 7za.exe (ia32): ${ia32Exe}`);
   else console.log("  ⚠️  7za.exe not found in ia32 installer — falling back to x64");
-  bundleWin("7zip-win-ia32", ia32Exe ?? winX64Exe);
+  bundleWin("7zip-win-ia32", ia32Exe ?? winIa32ExtraExe);
 }
 
 // ─── Checksums ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #222.

The 7-Zip *extra* package roots the **32-bit x86** console build; the 64-bit and ARM64 builds live in its `x64/` and `arm64/` subdirectories. `buildWin()` bundled the root binary, so `7zip-win-x64` (and the arm64 fallback) shipped a 32-bit `7za.exe` — which caps 7-Zip's compression memory budget at 80% of 1.75 GiB, silently collapsing LZMA2 multithreading to ~1 encoder for every consumer (details and measurements in #222: swapping the x64 build of the same release took a 6.4 GiB nsis-web pack from 35.2 to 5.0 min).

- `7zip-win-x64` ← `x64/7za.exe`
- `7zip-win-arm64` ← prefer `arm64/7za.exe` from the extra package; NSIS-installer extraction stays as the fallback
- `7zip-win-ia32` fallback ← the extra package **root** binary (the x86 build — the only bundle it is correct for)

A new toolset release + checksum bump in app-builder-lib's `toolsets/7zip.ts` is needed to reach consumers.